### PR TITLE
(mostly) object resource

### DIFF
--- a/casymda_hardware/schema/device_block.py
+++ b/casymda_hardware/schema/device_block.py
@@ -25,11 +25,14 @@ class DeviceBlock(Block):
         # TODO test object resources are working
         resource_objects = [LabObjectResource.from_lab_object(obj, self.env) for obj in involved_objects]
         reqs = [ro.resource.request() for ro in resource_objects]
+        # note the device resource is requested/released in `_process_entity` of `Block`
         for req in reqs:
             yield req
+        print(f"requested: {[ro.resource.count for ro in resource_objects]}")
         yield self.env.timeout(processing_time)
         for i, ro in enumerate(resource_objects):
             req = reqs[i]
             ro.resource.release(req)
+            print(f"released: {[ro.resource.count for ro in resource_objects]}")
         self.device.act_by_instruction(job.instruction, is_pre=False)
         job.notify_processing_step_completion()

--- a/casymda_hardware/schema/device_block.py
+++ b/casymda_hardware/schema/device_block.py
@@ -3,6 +3,7 @@ from simpy.core import Environment
 
 from hardware_pydantic import Device
 from .instruction_job import InstructionJob
+from .object_resource import LabObjectResource
 
 
 class DeviceBlock(Block):
@@ -18,7 +19,17 @@ class DeviceBlock(Block):
 
     def actual_processing(self, job: InstructionJob):
         assert job.get_next_machine() == self.device.identifier
-        processing_time = self.device.project_by_instruction(job.instruction)
+        involved_objects, processing_time = self.device.act_by_instruction(job.instruction, is_pre=True)
+        print(f"projected processing time: {job.identifier} == {processing_time}")
+        print(f"involved objects: {involved_objects}")
+        # TODO test object resources are working
+        resource_objects = [LabObjectResource.from_lab_object(obj, self.env) for obj in involved_objects]
+        reqs = [ro.resource.request() for ro in resource_objects]
+        for req in reqs:
+            yield req
         yield self.env.timeout(processing_time)
-        self.device.act_by_instruction(job.instruction)
+        for i, ro in enumerate(resource_objects):
+            req = reqs[i]
+            ro.resource.release(req)
+        self.device.act_by_instruction(job.instruction, is_pre=False)
         job.notify_processing_step_completion()

--- a/casymda_hardware/schema/instruction_job.py
+++ b/casymda_hardware/schema/instruction_job.py
@@ -63,4 +63,4 @@ class InstructionJob(Entity):
 
     def get_next_machine(self) -> str:
         # return list(self._machines_times.items())[self._num_completed_machines][0]
-        return self.instruction.actor_device.identifier
+        return self.instruction.device.identifier

--- a/casymda_hardware/schema/object_resource.py
+++ b/casymda_hardware/schema/object_resource.py
@@ -1,0 +1,15 @@
+from simpy import Resource, Environment
+
+from hardware_pydantic.lab_objects import LabObject
+
+
+class LabObjectResource:
+
+    def __init__(self, lab_object: LabObject, resource: Resource, env: Environment):
+        self.lab_object = lab_object
+        self.resource = resource
+        self.env = env
+
+    @classmethod
+    def from_lab_object(cls, o: LabObject, env: Environment):
+        return cls(o, Resource(env, capacity=1), env)

--- a/hardware_pydantic/base.py
+++ b/hardware_pydantic/base.py
@@ -1,34 +1,10 @@
 from __future__ import annotations
 
 from typing import Any, Literal
-from uuid import uuid4
 
-from loguru import logger
 from pydantic import BaseModel, Field
 
-
-def str_uuid() -> str:
-    return str(uuid4())
-
-
-def resolve_function(func):
-    if isinstance(func, staticmethod):
-        return func.__func__
-    return func
-
-
-def action_method_logging(func):
-    """ logging decorator for `action_method` of a `Device` """
-
-    def function_caller(self: Device, *args, **kwargs):
-        _func = resolve_function(func)
-        logger.warning(f">> ACTION COMMITTED *{func.__name__}* of *{self.__class__.__name__}*: {self.identifier}")
-        for k, v in kwargs.items():
-            logger.info(f"action parameter name: {k}")
-            logger.info(f"action parameter value: {v}")
-        _func(self, *args, **kwargs)
-
-    return function_caller
+from .utils import str_uuid
 
 
 class Individual(BaseModel):
@@ -49,7 +25,8 @@ class LabObject(Individual):
     1. is not a chemical designed to participate in reactions
     2. has constant, physically defined 3D boundary
     3. has a (non empty) set of measurable qualities that need to be tracked, this set is the state of this `LabObject`
-        #TODO can we have a pydantic model history tracker? similar to https://pypi.org/project/pydantic-changedetect/
+        # TODO can we have a pydantic model history tracker? similar to https://pypi.org/project/pydantic-changedetect/
+        # TODO mutable fields vs immutable fields?
     """
 
     @property
@@ -63,72 +40,70 @@ class LabObject(Individual):
         return self.validate_state(self.state)
 
 
+class PreActError(Exception): pass
+
+
+class PostActError(Exception): pass
+
+
 class Device(LabObject):
     """
     a `LabObject` that
-
     1. can receive instructions
     2. can change its state and other lab objects' states using its action methods,
-        it cannot change another device's state!
+    3. cannot change another device's state
 
-    an action method's name follows "action__{action_name}"
-
-    a problem in simulation:
-    an action should change the states of involved objects after the required time has passed
-    this means
-        - the time cost for finishing this action should be first computed at runtime
-        - then, after the time has passed, change the states of objects through the action method
-    we call the former a `projection`, an action method should always be accompanied by a projection method
-    # TODO a decorator to check this pairing
+    # TODO a decorator to check pairing of pre__ and post__
     """
 
     @property
-    def action_names(self):
-        """ a sorted list of the names of all defined action methods """
-        return sorted({k[8:] for k in dir(self) if k.startswith("action__")})
+    def action_names(self) -> list[str]:
+        """ a sorted list of the names of all defined actions """
+        prefix = "pre__"
+        names = sorted({k[len(prefix):] for k in dir(self) if k.startswith(prefix)})
+        return names
 
     @staticmethod
-    def get_projection_method_name(action_name: str):
-        return f"projection__{action_name}"
+    def get_pre_actor_name(action_name: str) -> str:
+        return f"pre__{action_name}"
 
     @staticmethod
-    def get_action_method_name(action_name: str):
-        return f"action__{action_name}"
+    def get_post_actor_name(action_name: str) -> str:
+        return f"post__{action_name}"
 
-    def project(self, action_name: str = "dummy", action_parameters: dict[str, Any] = None) -> float:
-        """ projection method uses the same `action_parameters` """
+    def act(
+            self,
+            action_name: str = "dummy",
+            action_parameters: dict[str, Any] = None,
+            is_pre=True,
+    ):
+        assert action_name in self.action_names, f"{action_name} not in {self.action_names}"
         if action_parameters is None:
             action_parameters = dict()
-        assert action_name in self.action_names
-        projection_method_name = Device.get_projection_method_name(action_name)
-        return getattr(self, projection_method_name)(**action_parameters)
+        if is_pre:
+            method_name = Device.get_pre_actor_name(action_name)
+        else:
+            method_name = Device.get_post_actor_name(action_name)
+        return getattr(self, method_name)(**action_parameters)
 
-    def act(self, action_name: str = "dummy", action_parameters: dict[str, Any] = None) -> None:
+    def pre__dummy(self, **kwargs) -> tuple[list[LabObject], float]:
         """
-        perform the action defined by `action_method_name`,
-        note an action method will always return the time cost
+        1. return a list of all involved objects, except self
+        2. check the current states of involved objects, raise PreActorError if not met
+        3. return the projected time cost
         """
-        if action_parameters is None:
-            action_parameters = dict()
-        assert action_name in self.action_names
-        action_method_name = Device.get_action_method_name(action_name)
-        getattr(self, action_method_name)(**action_parameters)
+        return [], 0
 
-    def act_by_instruction(self, i: Instruction) -> None:
+    def post__dummy(self, **kwargs) -> None:
+        """
+        1. make state transitions for involved objects, raise PostActorError if illegal transition
+        """
+        return
+
+    def act_by_instruction(self, i: Instruction, is_pre: bool):
         """ perform action with an instruction """
-        assert i.actor_device == self
-        self.act(action_name=i.action_name, action_parameters=i.action_parameters, )
-
-    def project_by_instruction(self, i: Instruction) -> float:
-        assert i.actor_device == self
-        return self.project(action_name=i.action_name, action_parameters=i.action_parameters, )
-
-    @action_method_logging
-    def action__dummy(self, **kwargs):
-        pass
-
-    def project__dummy(self, **kwargs) -> float:
-        return 1e-5
+        assert i.device == self
+        return self.act(action_name=i.action_name, action_parameters=i.action_parameters, is_pre=is_pre)
 
 
 class Instruction(Individual):
@@ -137,9 +112,9 @@ class Instruction(Individual):
 
     instruction:
     - an instruction is sent to and received by one and only one `Device` instance (the `actor`) instantly
-    - an instruction requests one and only one `action_method` from the `Device` instance
+    - an instruction requests one and only one `action_name` from the `Device` instance
     - an instruction contains static parameters that the `action_method` needs
-    - an instruction can involve zero, one or more `LabObject` instances
+    - an instruction can involve zero or more `LabObject` instances
     - an instruction cannot involve any `Device` instance except the `actor`
 
     action:
@@ -151,7 +126,7 @@ class Instruction(Individual):
         - ends when
             - the duration, returned by the action method of the actor, has passed
     """
-    actor_device: Device
+    device: Device
     action_parameters: dict = dict()
     action_name: str = "dummy"
     description: str = ""
@@ -162,12 +137,12 @@ class Instruction(Individual):
 
 class Lab(BaseModel):
     dict_instruction: dict[str, Instruction] = dict()
-    dict_object: dict[str, LabObject] = dict()
+    dict_object: dict[str, LabObject | Device] = dict()
 
-    def act_by_instruction(self, i: Instruction):
-        actor = self.dict_object[i.actor_device.identifier]  # make sure we are working on the same device
+    def act_by_instruction(self, i: Instruction, is_pre: bool = True):
+        actor = self.dict_object[i.device.identifier]  # make sure we are working on the same device
         assert isinstance(actor, Device)
-        return actor.act_by_instruction(i)
+        return actor.act_by_instruction(i, is_pre=is_pre)
 
     def add_instruction(self, i: Instruction):
         assert i.identifier not in self.dict_instruction

--- a/hardware_pydantic/example.py
+++ b/hardware_pydantic/example.py
@@ -25,7 +25,7 @@ for ilabel, label in enumerate(rack1.content):
 # move vial1 from rack1 to heater1
 ins_move_rack1_to_heater1 = Instruction(
     identifier="ins_move_rack1_to_heater1",
-    actor_device=transferor1,
+    device=transferor1,
     action_name="transfer",
     action_parameters={
         "from_obj": rack1,
@@ -38,7 +38,7 @@ ins_move_rack1_to_heater1 = Instruction(
 # move vial1 from heater1 to rack2
 ins_move_heater1_to_rack2 = Instruction(
     identifier="ins_move_heater1_to_rack2",
-    actor_device=transferor2,
+    device=transferor2,
     action_name="transfer",
     action_parameters={
         "from_obj": heater1,
@@ -51,7 +51,7 @@ ins_move_heater1_to_rack2 = Instruction(
 
 ins_set_heater1_to_200 = Instruction(
     identifier="ins_set_heater1_to_200",
-    actor_device=heater1,
+    device=heater1,
     action_name="set_point",
     action_parameters={
         "set_point": 200,
@@ -61,7 +61,7 @@ ins_set_heater1_to_200 = Instruction(
 
 ins_heater1_heating_to_set_point = Instruction(
     identifier="ins_heater1_heating_to_set_point",
-    actor_device=heater1,
+    device=heater1,
     action_name="heat_process",
     action_parameters={},
     preceding_instructions=[ins_set_heater1_to_200.identifier, ]
@@ -78,26 +78,72 @@ if __name__ == '__main__':
     lab.act_by_instruction(ins_set_heater1_to_200)
     lab.act_by_instruction(ins_heater1_heating_to_set_point)
     """
-    2023-05-22 15:06:16.420 | WARNING  | hardware_pydantic.base:function_caller:25 - >> ACTION COMMITTED *action__transfer* of *VialTransferor*: crane1
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: from_obj
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: identifier='rack1' content={'A1': 'vial1', 'A2': 'vial2', 'B1': 'vial3', 'B2': 'vial4'}
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: to_obj
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: identifier='heater1' set_point=25 reading=25 content=None
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: transferee
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: identifier='vial1' position='A1' position_relative='rack1' content={}
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: to_position
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: None
-    2023-05-22 15:06:16.421 | WARNING  | hardware_pydantic.base:function_caller:25 - >> ACTION COMMITTED *action__transfer* of *VialTransferor*: crane2
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: from_obj
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: identifier='heater1' set_point=25 reading=25 content=None
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: to_obj
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: identifier='rack2' content={'A1': None, 'A2': None, 'B1': None, 'B2': None}
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: transferee
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: identifier='vial1' position='A1' position_relative='rack1' content={}
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: to_position
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: A2
-    2023-05-22 15:06:16.421 | WARNING  | hardware_pydantic.base:function_caller:25 - >> ACTION COMMITTED *action__set_point* of *Heater*: heater1
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:27 - action parameter name: set_point
-    2023-05-22 15:06:16.421 | INFO     | hardware_pydantic.base:function_caller:28 - action parameter value: 200
-    2023-05-22 15:06:16.421 | WARNING  | hardware_pydantic.base:function_caller:25 - >> ACTION COMMITTED *action__heat_process* of *Heater*: heater1
+    ins_move_rack1_to_heater1  ready at: 0
+    projected processing time: InstructionJob: ins_move_rack1_to_heater1 == 5
+    involved objects: [Heater(identifier='heater1', set_point=25, set_point_max=400, reading=25, content=None), Vial(identifier='vial1', position='A1', position_relative='rack1', content={})]
+    FINISHED STEP
+    InstructionJob: ins_move_rack1_to_heater1 at: 5
+    CURRENT LAB:
+    rack1: {'identifier': 'rack1', 'content': {'A1': None, 'A2': 'vial2', 'B1': 'vial3', 'B2': 'vial4'}}
+    rack2: {'identifier': 'rack2', 'content': {'A1': None, 'A2': None, 'B1': None, 'B2': None}}
+    crane1: {'identifier': 'crane1'}
+    crane2: {'identifier': 'crane2'}
+    heater1: {'identifier': 'heater1', 'set_point': 25, 'set_point_max': 400, 'reading': 25, 'content': 'vial1'}
+    heater2: {'identifier': 'heater2', 'set_point': 25, 'set_point_max': 400, 'reading': 25, 'content': None}
+    vial1: {'identifier': 'vial1', 'position': None, 'position_relative': 'heater1', 'content': {}}
+    vial2: {'identifier': 'vial2', 'position': 'A2', 'position_relative': 'rack1', 'content': {}}
+    vial3: {'identifier': 'vial3', 'position': 'B1', 'position_relative': 'rack1', 'content': {}}
+    vial4: {'identifier': 'vial4', 'position': 'B2', 'position_relative': 'rack1', 'content': {}}
+    ============
+    ins_set_heater1_to_200  ready at: 5
+    ins_move_heater1_to_rack2  ready at: 5
+    projected processing time: InstructionJob: ins_set_heater1_to_200 == 1e-05
+    involved objects: []
+    projected processing time: InstructionJob: ins_move_heater1_to_rack2 == 5
+    involved objects: [Rack(identifier='rack2', content={'A1': None, 'A2': None, 'B1': None, 'B2': None}), Vial(identifier='vial1', position=None, position_relative='heater1', content={})]
+    FINISHED STEP
+    InstructionJob: ins_set_heater1_to_200 at: 5.00001
+    CURRENT LAB:
+    rack1: {'identifier': 'rack1', 'content': {'A1': None, 'A2': 'vial2', 'B1': 'vial3', 'B2': 'vial4'}}
+    rack2: {'identifier': 'rack2', 'content': {'A1': None, 'A2': None, 'B1': None, 'B2': None}}
+    crane1: {'identifier': 'crane1'}
+    crane2: {'identifier': 'crane2'}
+    heater1: {'identifier': 'heater1', 'set_point': 200, 'set_point_max': 400, 'reading': 25, 'content': 'vial1'}
+    heater2: {'identifier': 'heater2', 'set_point': 25, 'set_point_max': 400, 'reading': 25, 'content': None}
+    vial1: {'identifier': 'vial1', 'position': None, 'position_relative': 'heater1', 'content': {}}
+    vial2: {'identifier': 'vial2', 'position': 'A2', 'position_relative': 'rack1', 'content': {}}
+    vial3: {'identifier': 'vial3', 'position': 'B1', 'position_relative': 'rack1', 'content': {}}
+    vial4: {'identifier': 'vial4', 'position': 'B2', 'position_relative': 'rack1', 'content': {}}
+    ============
+    ins_heater1_heating_to_set_point  ready at: 5.00001
+    projected processing time: InstructionJob: ins_heater1_heating_to_set_point == 17.5
+    involved objects: []
+    FINISHED STEP
+    InstructionJob: ins_move_heater1_to_rack2 at: 10
+    CURRENT LAB:
+    rack1: {'identifier': 'rack1', 'content': {'A1': None, 'A2': 'vial2', 'B1': 'vial3', 'B2': 'vial4'}}
+    rack2: {'identifier': 'rack2', 'content': {'A1': None, 'A2': 'vial1', 'B1': None, 'B2': None}}
+    crane1: {'identifier': 'crane1'}
+    crane2: {'identifier': 'crane2'}
+    heater1: {'identifier': 'heater1', 'set_point': 200, 'set_point_max': 400, 'reading': 25, 'content': None}
+    heater2: {'identifier': 'heater2', 'set_point': 25, 'set_point_max': 400, 'reading': 25, 'content': None}
+    vial1: {'identifier': 'vial1', 'position': 'A2', 'position_relative': 'rack2', 'content': {}}
+    vial2: {'identifier': 'vial2', 'position': 'A2', 'position_relative': 'rack1', 'content': {}}
+    vial3: {'identifier': 'vial3', 'position': 'B1', 'position_relative': 'rack1', 'content': {}}
+    vial4: {'identifier': 'vial4', 'position': 'B2', 'position_relative': 'rack1', 'content': {}}
+    ============
+    FINISHED STEP
+    InstructionJob: ins_heater1_heating_to_set_point at: 22.50001
+    CURRENT LAB:
+    rack1: {'identifier': 'rack1', 'content': {'A1': None, 'A2': 'vial2', 'B1': 'vial3', 'B2': 'vial4'}}
+    rack2: {'identifier': 'rack2', 'content': {'A1': None, 'A2': 'vial1', 'B1': None, 'B2': None}}
+    crane1: {'identifier': 'crane1'}
+    crane2: {'identifier': 'crane2'}
+    heater1: {'identifier': 'heater1', 'set_point': 200, 'set_point_max': 400, 'reading': 200, 'content': None}
+    heater2: {'identifier': 'heater2', 'set_point': 25, 'set_point_max': 400, 'reading': 25, 'content': None}
+    vial1: {'identifier': 'vial1', 'position': 'A2', 'position_relative': 'rack2', 'content': {}}
+    vial2: {'identifier': 'vial2', 'position': 'A2', 'position_relative': 'rack1', 'content': {}}
+    vial3: {'identifier': 'vial3', 'position': 'B1', 'position_relative': 'rack1', 'content': {}}
+    vial4: {'identifier': 'vial4', 'position': 'B2', 'position_relative': 'rack1', 'content': {}}
+    ============
     """

--- a/hardware_pydantic/lab_objects.py
+++ b/hardware_pydantic/lab_objects.py
@@ -10,6 +10,8 @@ class Vial(LabObject):
 
     @property
     def content_sum(self) -> float:
+        if len(self.content) == 0:
+            return 0
         return sum(self.content.values())
 
     def add_content(self, content: dict[str, float]):

--- a/hardware_pydantic/utils.py
+++ b/hardware_pydantic/utils.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from loguru import logger
+
+
+def str_uuid() -> str:
+    return str(uuid4())
+
+
+def resolve_function(func):
+    if isinstance(func, staticmethod):
+        return func.__func__
+    return func
+
+
+def action_method_logging(func):
+    # TODO modify it to fit pre__ and post__
+    """ logging decorator for `action_method` of a `Device` """
+
+    def function_caller(self, *args, **kwargs):
+        _func = resolve_function(func)
+        logger.warning(f">> ACTION COMMITTED *{func.__name__}* of *{self.__class__.__name__}*: {self.identifier}")
+        for k, v in kwargs.items():
+            logger.info(f"action parameter name: {k}")
+            logger.info(f"action parameter value: {v}")
+        _func(self, *args, **kwargs)
+
+    return function_caller


### PR DESCRIPTION
- added `LabObjectResource` in `casymda.hardware` to occupy resources, they are requested/released in `DeviceBlock`
- consolidated action-related methods: now for each action, there are only two methods, `pre__<action_name>` and `post__<action_name>`
  - `pre` check preconditions, project processing time, detect objects that will be occupied, returns `tuple[list[LabObject], float]`
  - `post` make state transitions, returns `None`
- some trivial refactoring