### PR TITLE
Representation kg

### DIFF
--- a/casymda_hardware/schema/instruction_job.py
+++ b/casymda_hardware/schema/instruction_job.py
@@ -82,4 +82,4 @@ class InstructionJob(Entity):
 
     def get_next_machine(self) -> str:
         """Get the next machine to process this job."""
-        return self.instruction.send_to_device.get_range_assume_one().identifier
+        return list(self.instruction.send_to_device)[0].identifier

--- a/casymda_hardware/schema/instruction_job.py
+++ b/casymda_hardware/schema/instruction_job.py
@@ -82,4 +82,4 @@ class InstructionJob(Entity):
 
     def get_next_machine(self) -> str:
         """Get the next machine to process this job."""
-        return self.instruction.device.identifier
+        return self.instruction.send_to_device.get_range_assume_one().identifier

--- a/casymda_hardware/schema/source.py
+++ b/casymda_hardware/schema/source.py
@@ -50,7 +50,7 @@ class Source(Block):
         for instruction_job in dict_instruction_job.values():
 
             preceding_jobs_completion_events = []
-            for predecessor_identifier in instruction_job.instruction.preceding_instructions:
+            for predecessor_identifier in instruction_job.instruction.preceding_instructions.range:
                 preceding_instruction_job = dict_instruction_job[predecessor_identifier]
                 preceding_jobs_completion_events.append(
                     preceding_instruction_job.is_completed_event

--- a/casymda_hardware/schema/source.py
+++ b/casymda_hardware/schema/source.py
@@ -50,7 +50,7 @@ class Source(Block):
         for instruction_job in dict_instruction_job.values():
 
             preceding_jobs_completion_events = []
-            for predecessor_identifier in instruction_job.instruction.preceding_instructions.range:
+            for predecessor_identifier in instruction_job.instruction.preceding_instructions:
                 preceding_instruction_job = dict_instruction_job[predecessor_identifier]
                 preceding_jobs_completion_events.append(
                     preceding_instruction_job.is_completed_event

--- a/hardware_pydantic/base.py
+++ b/hardware_pydantic/base.py
@@ -190,7 +190,10 @@ class Instruction(Individual):
 
     def as_dict(self, identifier_only=True):
         if identifier_only:
-            d = self.model_dump()
+
+            # TODO this is a semi-magic from https://github.com/pydantic/pydantic/issues/4186
+            d = self.model_dump(mode="json")
+
             dict_action_parameters = dict()
             for k, v in self.action_parameters.items():
                 if isinstance(v, LabObject):

--- a/hardware_pydantic/base.py
+++ b/hardware_pydantic/base.py
@@ -5,8 +5,8 @@ from typing import Any, Literal, Type, ClassVar
 from N2G import drawio_diagram  # only used for drawing instruction DAG
 from pydantic import BaseModel, Field
 
-from py4jps.data_model.base_ontology import BaseOntology, BaseClass, ObjectProperty, DataProperty
-from py4jps.data_model.base_ontology import as_range_of_data_property, as_range_of_object_property
+from twa.data_model.base_ontology import BaseOntology, BaseClass, ObjectProperty, DataProperty
+from twa.data_model.base_ontology import as_range_of_data_property, as_range_of_object_property
 
 
 from .utils import str_uuid

--- a/hardware_pydantic/junior/benchtop/tips_pn_grignard.py
+++ b/hardware_pydantic/junior/benchtop/tips_pn_grignard.py
@@ -49,7 +49,8 @@ implemented as a path graph rn, ef can be made independent from abcd
 """
 
 
-class GrignardBenchtop(BaseModel):
+class GrignardBenchtop(BaseClass):
+    rdfs_isDefinedBy = JuniorOntology
     RACK_LIQUID: JuniorRack
     THF_VIALS: list[JuniorVial]
     HCL_VIALS: list[JuniorVial]
@@ -88,7 +89,7 @@ def setup_grignard_benchtop(
 
     # create a rack for HRVs on off-deck, fill them with thf,
     rack_liquid, liquid_vials = JuniorRack.create_rack_with_empty_vials(
-        n_vials=n_thf_source_vials + n_hcl_source_vials, rack_capacity=12, vial_type="HRV", rack_id="RACK_LIQUID"
+        n_vials=n_thf_source_vials + n_hcl_source_vials, rack_capacity=12, vial_type="HRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK_LIQUID"
     )
     thf_vials = liquid_vials[:n_thf_source_vials]
     hcl_vials = liquid_vials[- n_hcl_source_vials:]
@@ -103,37 +104,39 @@ def setup_grignard_benchtop(
 
     # create a rack for MRVs (reactors) on 2-3-1
     rack_reactor, reactor_vials = JuniorRack.create_rack_with_empty_vials(
-        n_vials=n_reactors, rack_capacity=6, vial_type="MRV", rack_id="RACK_REACTOR"
+        n_vials=n_reactors, rack_capacity=6, vial_type="MRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK_REACTOR"
     )
     JuniorSlot.put_rack_in_a_slot(rack_reactor, junior_benchtop.SLOT_2_3_1)
 
     # create a rack for HRVs on 2-3-2, one for silyl one for quinone sln
     rack_reactant, (silyl_vial, quinone_vial) = JuniorRack.create_rack_with_empty_vials(
-        n_vials=2, rack_capacity=6, vial_type="HRV", rack_id="RACK_REACTANT"
+        n_vials=2, rack_capacity=6, vial_type="HRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK_REACTANT"
     )
     silyl_vial.chemical_content = {'silyl': silyl_init_volume}
     JuniorSlot.put_rack_in_a_slot(rack_reactant, junior_benchtop.SLOT_2_3_2)
 
     # create a rack for PDP tips on 2-3-3
     rack_pdp_tips, pdp_tips = JuniorRack.create_rack_with_empty_tips(
-        n_tips=n_pdp_tips, rack_capacity=8, rack_id="RACK_PDP_TIPS", tip_id_inherit=True
+        n_tips=n_pdp_tips, rack_capacity=8, rack_id=f"{JuniorOntology.namespace_iri}/RACK_PDP_TIPS", tip_id_inherit=True
     )
     JuniorSlot.put_rack_in_a_slot(rack_pdp_tips, junior_benchtop.SLOT_2_3_3)
 
     # SV VIALS for quinone, grignard
     quinone_svv = JuniorVial(
-        identifier="QUINONE_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[0].identifier,
-        chemical_content={'Quinone': quinone_init_amount},
+        identifier=f"{JuniorOntology.namespace_iri}/QUINONE_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[0].identifier,
         vial_type='SV',
+        is_contained_in_slot='SLOT',
     )
+    quinone_svv.chemical_content = {'Quinone': quinone_init_amount}
     grignard_svv = JuniorVial(
-        identifier="GRIGNARD_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[1].identifier,
-        chemical_content={'Grignard': grignard_init_amount},
+        identifier=f"{JuniorOntology.namespace_iri}/GRIGNARD_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[1].identifier,
         vial_type='SV',
+        is_contained_in_slot='SLOT',
     )
+    grignard_svv.chemical_content = {'Grignard': grignard_init_amount}
 
-    junior_benchtop.SV_VIAL_SLOTS[0].slot_content['SLOT'] = quinone_svv.identifier
-    junior_benchtop.SV_VIAL_SLOTS[1].slot_content['SLOT'] = grignard_svv.identifier
+    junior_benchtop.SV_VIAL_SLOTS[0].has_slot_content.add(quinone_svv)
+    junior_benchtop.SV_VIAL_SLOTS[1].has_slot_content.add(grignard_svv)
 
     return GrignardBenchtop(
         RACK_LIQUID=rack_liquid,

--- a/hardware_pydantic/junior/benchtop/tips_pn_quinone.py
+++ b/hardware_pydantic/junior/benchtop/tips_pn_quinone.py
@@ -43,7 +43,8 @@ g. react rt 4h
 """
 
 
-class QuinoneBenchtop(BaseModel):
+class QuinoneBenchtop(BaseClass):
+    rdfs_isDefinedBy = JuniorOntology
     RACK_LIQUID: JuniorRack
     ETHANOL_VIALS: list[JuniorVial]
     WATER_VIALS: list[JuniorVial]
@@ -84,7 +85,7 @@ def setup_quinone_benchtop(
 
     # create a rack for HRVs on off-deck, fill them with ethanol,
     rack_liquid, liquid_vials = JuniorRack.create_rack_with_empty_vials(
-        n_vials=n_ethanol_source_vials + 1, rack_capacity=12, vial_type="HRV", rack_id="RACK_LIQUID"
+        n_vials=n_ethanol_source_vials + 1, rack_capacity=12, vial_type="HRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK_LIQUID"
     )
     ethanol_vials = liquid_vials[:-1]
     water_vial = liquid_vials[-1]
@@ -96,41 +97,44 @@ def setup_quinone_benchtop(
 
     # create a rack for MRVs (reactors) on 2-3-1
     rack_reactor, reactor_vials = JuniorRack.create_rack_with_empty_vials(
-        n_vials=n_reactors, rack_capacity=12, vial_type="MRV", rack_id="RACK_REACTOR"
+        n_vials=n_reactors, rack_capacity=12, vial_type="MRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK_REACTOR"
     )
     JuniorSlot.put_rack_in_a_slot(rack_reactor, junior_benchtop.SLOT_2_3_1)
 
     # create a rack for HRVs on 2-3-2, one for diketone one for naoh aq.
     rack_reactant, (diketone_vial, naoh_vial) = JuniorRack.create_rack_with_empty_vials(
-        n_vials=2, rack_capacity=12, vial_type="HRV", rack_id="RACK_REACTANT"
+        n_vials=2, rack_capacity=12, vial_type="HRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK_REACTANT"
     )
     JuniorSlot.put_rack_in_a_slot(rack_reactant, junior_benchtop.SLOT_2_3_2)
 
     # create a rack for PDP tips on 2-3-3
     rack_pdp_tips, pdp_tips = JuniorRack.create_rack_with_empty_tips(
-        n_tips=n_pdp_tips, rack_capacity=36, rack_id="RACK_PDP_TIPS", tip_id_inherit=True
+        n_tips=n_pdp_tips, rack_capacity=36, rack_id=f"{JuniorOntology.namespace_iri}/RACK_PDP_TIPS", tip_id_inherit=True
     )
     JuniorSlot.put_rack_in_a_slot(rack_pdp_tips, junior_benchtop.SLOT_2_3_3)
 
     # SV VIALS for diketone, aldehyde, naoh
     diketone_svv = JuniorVial(
-        identifier="DIKETONE_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[0].identifier,
-        chemical_content={'Diketone': diketone_init_amount},
+        identifier=f"{JuniorOntology.namespace_iri}/DIKETONE_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[0].identifier,
         vial_type='SV',
+        is_contained_in_slot='SLOT',
     )
+    diketone_svv.chemical_content = {'Diketone': diketone_init_amount}
     aldehyde_svv = JuniorVial(
-        identifier="ALDEHYDE_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[1].identifier,
-        chemical_content={'Aledehyde': aldehyde_init_amount},
+        identifier=f"{JuniorOntology.namespace_iri}/ALDEHYDE_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[1].identifier,
         vial_type='SV',
+        is_contained_in_slot='SLOT',
     )
+    aldehyde_svv.chemical_content = {'Aledehyde': aldehyde_init_amount}
     naoh_svv = JuniorVial(
-        identifier="NAOH_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[2].identifier,
-        chemical_content={'NaOH': naoh_init_amount},
+        identifier=f"{JuniorOntology.namespace_iri}/NAOH_SVV", contained_by=junior_benchtop.SV_VIAL_SLOTS[2].identifier,
         vial_type='SV',
+        is_contained_in_slot='SLOT',
     )
-    junior_benchtop.SV_VIAL_SLOTS[0].slot_content['SLOT'] = diketone_svv.identifier
-    junior_benchtop.SV_VIAL_SLOTS[1].slot_content['SLOT'] = aldehyde_svv.identifier
-    junior_benchtop.SV_VIAL_SLOTS[2].slot_content['SLOT'] = naoh_svv.identifier
+    naoh_svv.chemical_content = {'NaOH': naoh_init_amount}
+    junior_benchtop.SV_VIAL_SLOTS[0].has_slot_content.add(diketone_svv)
+    junior_benchtop.SV_VIAL_SLOTS[1].has_slot_content.add(aldehyde_svv)
+    junior_benchtop.SV_VIAL_SLOTS[2].has_slot_content.add(naoh_svv)
 
     return QuinoneBenchtop(
         RACK_LIQUID=rack_liquid,

--- a/hardware_pydantic/junior/instruction_prototype/needle_dispense.py
+++ b/hardware_pydantic/junior/instruction_prototype/needle_dispense.py
@@ -9,7 +9,7 @@ def needle_dispense(
         dest_vials_slot: JuniorSlot,
         amounts: list[float],
 ):
-    z1_needles = [JUNIOR_LAB[f"Z1 Needle {i + 1}"] for i in range(len(amounts))]
+    z1_needles = [JUNIOR_LAB[f"{JuniorOntology.namespace_iri}/Z1-Needle-{i + 1}"] for i in range(len(amounts))]
     ins1 = JuniorInstruction(
         send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={

--- a/hardware_pydantic/junior/instruction_prototype/needle_dispense.py
+++ b/hardware_pydantic/junior/instruction_prototype/needle_dispense.py
@@ -11,7 +11,7 @@ def needle_dispense(
 ):
     z1_needles = [JUNIOR_LAB[f"Z1 Needle {i + 1}"] for i in range(len(amounts))]
     ins1 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z1,
             "move_to_slot": src_slot,
@@ -19,7 +19,7 @@ def needle_dispense(
         description=f"move to slot: {src_slot.identifier}"
     )
     ins2 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z1, action_name="concurrent_aspirate",
+        send_to_device=junior_benchtop.ARM_Z1, action_name="concurrent_aspirate",
         action_parameters={
             "source_containers": src_vials,
             "dispenser_containers": z1_needles,
@@ -28,7 +28,7 @@ def needle_dispense(
         description=f"concurrent aspirate from: {','.join([v.identifier for v in src_vials])}"
     )
     ins3 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z1,
             "move_to_slot": dest_vials_slot,
@@ -36,7 +36,7 @@ def needle_dispense(
         description=f"move to slot: {dest_vials_slot.identifier}"
     )
     ins4 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z1, action_name="concurrent_dispense",
+        send_to_device=junior_benchtop.ARM_Z1, action_name="concurrent_dispense",
         action_parameters={
             "destination_containers": dest_vials,
             "dispenser_containers": z1_needles,
@@ -45,7 +45,7 @@ def needle_dispense(
         description=f"concurrent dispense to: {','.join([v.identifier for v in dest_vials])}"
     )
     ins5 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z1,
             "move_to_slot": junior_benchtop.WASH_BAY,
@@ -53,7 +53,7 @@ def needle_dispense(
         description=f"move to slot: WASH BAY"
     )
     ins6 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z1, action_name="wash",
+        send_to_device=junior_benchtop.ARM_Z1, action_name="wash",
         action_parameters={
             "wash_bay": junior_benchtop.WASH_BAY,
         },

--- a/hardware_pydantic/junior/instruction_prototype/pdp_dispense.py
+++ b/hardware_pydantic/junior/instruction_prototype/pdp_dispense.py
@@ -14,7 +14,7 @@ def pdp_dispense(
 
     if include_pickup_pdp:
         ins1 = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": junior_benchtop.SLOT_PDT_1,
@@ -23,7 +23,7 @@ def pdp_dispense(
         )
 
         ins2 = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="pick_up",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="pick_up",
             action_parameters={"thing": junior_benchtop.PDP_1},
             description=f"pick up: {junior_benchtop.PDP_1.identifier}",
         )
@@ -31,7 +31,7 @@ def pdp_dispense(
 
     for tip, dest_vial in zip(tips, dest_vials):
         i_a = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": tips_slot,
@@ -39,12 +39,12 @@ def pdp_dispense(
             description=f"move to slot: {tips_slot.identifier}"
         )
         i_b = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="pick_up",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="pick_up",
             action_parameters={"thing": tip},
             description=f"pick up: {tip.identifier}",
         )
         i_c = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": src_slot,
@@ -52,7 +52,7 @@ def pdp_dispense(
             description=f"move to slot: {src_slot.identifier}"
         )
         i_d = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="aspirate_pdp",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="aspirate_pdp",
             action_parameters={
                 "source_container": src_vial,
                 "amount": amount,
@@ -61,7 +61,7 @@ def pdp_dispense(
             description=f"aspirate_pdp from: {src_vial.identifier} amount: {amount}"
         )
         i_e = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": dest_vials_slot,
@@ -69,7 +69,7 @@ def pdp_dispense(
             description=f"move to slot: {dest_vials_slot.identifier}"
         )
         i_f = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="dispense_pdp",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="dispense_pdp",
             action_parameters={
                 "destination_container": dest_vial,
                 "amount": amount,
@@ -78,7 +78,7 @@ def pdp_dispense(
             description=f"dispense_pdp to: {dest_vial.identifier}"
         )
         i_g = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": junior_benchtop.TIP_DISPOSAL,
@@ -86,7 +86,7 @@ def pdp_dispense(
             description=f"move to slot: DISPOSAL"
         )
         i_h = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="put_down",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="put_down",
             action_parameters={
                 "dest_slot": junior_benchtop.TIP_DISPOSAL,
             },
@@ -96,7 +96,7 @@ def pdp_dispense(
 
     if include_dropoff_pdp:
         ins_xx = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": junior_benchtop.SLOT_PDT_1,
@@ -104,7 +104,7 @@ def pdp_dispense(
             description=f"move to slot: {junior_benchtop.SLOT_PDT_1.identifier}"
         )
         ins_yy = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="put_down",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="put_down",
             action_parameters={
                 "dest_slot": junior_benchtop.SLOT_PDT_1,
             },

--- a/hardware_pydantic/junior/instruction_prototype/rack_transfer.py
+++ b/hardware_pydantic/junior/instruction_prototype/rack_transfer.py
@@ -6,7 +6,7 @@ def pick_drop_rack_to(
         rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorSlot
 ) -> list[JuniorInstruction]:
     ins1 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z2,
             "move_to_slot": junior_benchtop.VPG_SLOT,
@@ -15,7 +15,7 @@ def pick_drop_rack_to(
     )
 
     ins2 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z2, action_name="pick_up",
+        send_to_device=junior_benchtop.ARM_Z2, action_name="pick_up",
         action_parameters={
             "thing": junior_benchtop.VPG,
         },
@@ -23,7 +23,7 @@ def pick_drop_rack_to(
     )
 
     ins3 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z2,
             "move_to_slot": src_slot,
@@ -31,14 +31,14 @@ def pick_drop_rack_to(
         description=f"move to slot: {src_slot.identifier}"
     )
     ins4 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z2, action_name="pick_up",
+        send_to_device=junior_benchtop.ARM_Z2, action_name="pick_up",
         action_parameters={
             "thing": rack,
         },
         description=f"pick up: {rack.identifier}"
     )
     ins5 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z2,
             "move_to_slot": dest_slot,
@@ -46,7 +46,7 @@ def pick_drop_rack_to(
         description=f"move to slot: {dest_slot.identifier}"
     )
     ins6 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z2, action_name="put_down",
+        send_to_device=junior_benchtop.ARM_Z2, action_name="put_down",
         action_parameters={
             "dest_slot": dest_slot,
         },
@@ -54,7 +54,7 @@ def pick_drop_rack_to(
     )
 
     ins7 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z2,
             "move_to_slot": junior_benchtop.VPG_SLOT,
@@ -63,7 +63,7 @@ def pick_drop_rack_to(
     )
 
     ins8 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z2, action_name="put_down",
+        send_to_device=junior_benchtop.ARM_Z2, action_name="put_down",
         action_parameters={
             "dest_slot": junior_benchtop.VPG_SLOT,
         },

--- a/hardware_pydantic/junior/instruction_prototype/solid_dispense.py
+++ b/hardware_pydantic/junior/instruction_prototype/solid_dispense.py
@@ -12,7 +12,7 @@ def solid_dispense(
         include_dropoff_svtool=True,
 ):
     ins3 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z2,
             "move_to_slot": sv_vial_slot,
@@ -21,13 +21,13 @@ def solid_dispense(
     )
 
     ins4 = JuniorInstruction(
-        device=junior_benchtop.ARM_Z2, action_name="pick_up",
+        send_to_device=junior_benchtop.ARM_Z2, action_name="pick_up",
         action_parameters={"thing": sv_vial},
         description=f"pick up: {sv_vial.identifier}",
     )
 
     ins5 = JuniorInstruction(
-        device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+        send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": junior_benchtop.ARM_Z2,
             "move_to_slot": junior_benchtop.BALANCE,
@@ -37,7 +37,7 @@ def solid_dispense(
 
     if include_pickup_svtool:
         ins1 = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": junior_benchtop.SV_TOOL_SLOT,
@@ -46,7 +46,7 @@ def solid_dispense(
         )
 
         ins2 = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="pick_up",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="pick_up",
             action_parameters={"thing": junior_benchtop.SV_TOOL},
             description=f"pick up: {junior_benchtop.SV_TOOL.identifier}",
         )
@@ -56,7 +56,7 @@ def solid_dispense(
 
     for dest_vial in dest_vials:
         ins6 = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="dispense_sv",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="dispense_sv",
             action_parameters={
                 "destination_container": dest_vial,
                 "amount": amount,
@@ -68,7 +68,7 @@ def solid_dispense(
 
     if include_dropoff_svvial:
         ins7 = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": sv_vial_slot,
@@ -77,7 +77,7 @@ def solid_dispense(
         )
 
         ins8 = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="put_down",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="put_down",
             action_parameters={
                 "dest_slot": sv_vial_slot,
             },
@@ -88,7 +88,7 @@ def solid_dispense(
 
     if include_dropoff_svtool:
         ins9 = JuniorInstruction(
-            device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
+            send_to_device=junior_benchtop.ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": junior_benchtop.ARM_Z2,
                 "move_to_slot": junior_benchtop.SV_TOOL_SLOT,
@@ -97,7 +97,7 @@ def solid_dispense(
         )
 
         ins10 = JuniorInstruction(
-            device=junior_benchtop.ARM_Z2, action_name="put_down",
+            send_to_device=junior_benchtop.ARM_Z2, action_name="put_down",
             action_parameters={
                 "dest_slot": junior_benchtop.SV_TOOL_SLOT,
             },

--- a/hardware_pydantic/junior/instruction_prototype/utils.py
+++ b/hardware_pydantic/junior/instruction_prototype/utils.py
@@ -17,12 +17,12 @@ def chain_ins_lol(lol: list[list[JuniorInstruction]]):
     for i in range(len(lol) - 1):
         former = lol[i]
         latter = lol[i + 1]
-        latter[0].preceding_instructions.append(former[-1].identifier)
+        latter[0].preceding_instructions.add(former[-1].identifier)
 
 
 def ins_diverge_or_converge(ins1: JuniorInstruction, ins_lst: list[JuniorInstruction], diverge=True):
     for i in ins_lst:
         if diverge:
-            i.preceding_instructions.append(ins1.identifier)
+            i.preceding_instructions.add(ins1.identifier)
         else:
-            ins1.preceding_instructions.append(i.identifier)
+            ins1.preceding_instructions.add(i.identifier)

--- a/hardware_pydantic/junior/junior_devices.py
+++ b/hardware_pydantic/junior/junior_devices.py
@@ -120,7 +120,7 @@ class JuniorSlot(JuniorBaseHeater, JuniorBaseStirrer):
         if rack.contained_by is not None:
             prev_slot = JUNIOR_LAB[rack.contained_by]
             assert isinstance(prev_slot, JuniorSlot)
-            prev_slot.slot_content["SLOT"] = None
+            prev_slot.has_slot_content.remove(rack)
         assert rack.__class__.rdf_type in slot.can_contain
         rack.contained_by = slot.identifier
         rack.contained_in_slot = "SLOT"
@@ -726,7 +726,7 @@ class JuniorArmZ2(LabContainer, LabContainee, JuniorBaseLiquidDispenser):
         )
 
 # if __name__ == '__main__':
-#     slot = JuniorSlot(identifier="slot1", can_contain=[JuniorRack.__name__])
+#     slot = JuniorSlot(identifier="slot1", can_contain=[JuniorRack.rdf_type])
 #     jr, vials = JuniorRack.create_rack_with_empty_vials()
 #     JuniorSlot.put_rack_in_a_slot(jr, slot)
 #     # print(LabContainer.get_all_containees(slot, JUNIOR_LAB))

--- a/hardware_pydantic/junior/junior_lab.py
+++ b/hardware_pydantic/junior/junior_lab.py
@@ -2,7 +2,8 @@ from hardware_pydantic.junior.junior_devices import *
 from hardware_pydantic.junior.settings import *
 
 
-class JuniorBenchtop(BaseModel):
+class JuniorBenchtop(BaseClass):
+    is_defined_by_ontology: ClassVar[Type[BaseOntology]] = JuniorOntology
     SLOT_OFF_1: JuniorSlot
     SLOT_OFF_2: JuniorSlot
     SLOT_OFF_3: JuniorSlot

--- a/hardware_pydantic/junior/junior_lab.py
+++ b/hardware_pydantic/junior/junior_lab.py
@@ -3,7 +3,7 @@ from hardware_pydantic.junior.settings import *
 
 
 class JuniorBenchtop(BaseClass):
-    is_defined_by_ontology: ClassVar[Type[BaseOntology]] = JuniorOntology
+    is_defined_by_ontology = JuniorOntology
     SLOT_OFF_1: JuniorSlot
     SLOT_OFF_2: JuniorSlot
     SLOT_OFF_3: JuniorSlot
@@ -47,50 +47,50 @@ def create_junior_base():
     assert len(JUNIOR_LAB.dict_object) == 0, "JUNIOR BASE HAS ALREADY BEEN INIT!!!"
 
     slot_off_1 = JuniorSlot(
-        identifier="SLOT OFF-1", can_contain=[JuniorRack.__name__, ],
+        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1", can_contain=[JuniorRack.get_rdf_type(), ],
         layout=JuniorLayout.from_relative_layout()
     )
     slot_off_2 = JuniorSlot(
-        identifier="SLOT OFF-2", can_contain=[JuniorRack.__name__, ],
-        layout=JuniorLayout.from_relative_layout("above", slot_off_1.layout)
+        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-OFF-2", can_contain=[JuniorRack.get_rdf_type(), ],
+        layout=JuniorLayout.from_relative_layout("above", slot_off_1.layout.get_range_assume_one())
     )
     slot_off_3 = JuniorSlot(
-        identifier="SLOT OFF-3", can_contain=[JuniorRack.__name__, ],
-        layout=JuniorLayout.from_relative_layout("above", slot_off_2.layout)
+        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-OFF-3", can_contain=[JuniorRack.get_rdf_type(), ],
+        layout=JuniorLayout.from_relative_layout("above", slot_off_2.layout.get_range_assume_one())
     )
 
     wash_bay = JuniorWashBay(
-        identifier="WASH BAY",
-        layout=JuniorLayout.from_relative_layout("right_to", slot_off_1.layout, JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL,
+        identifier=f"{JuniorOntology.get_namespace_iri()}/WASH-BAY",
+        layout=JuniorLayout.from_relative_layout("right_to", slot_off_1.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y * 3)
     )
 
     slot_2_3_1 = JuniorSlot(
-        identifier="SLOT 2-3-1", can_contain=[JuniorRack.__name__, ], can_heat=True, can_cool=True, can_stir=True,
-        layout=JuniorLayout.from_relative_layout("right_to", wash_bay.layout)
+        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1", can_contain=[JuniorRack.get_rdf_type(), ], can_heat=True, can_cool=True, can_stir=True,
+        layout=JuniorLayout.from_relative_layout("right_to", wash_bay.layout.get_range_assume_one())
     )
     slot_2_3_2 = JuniorSlot(
-        identifier="SLOT 2-3-2", can_contain=[JuniorRack.__name__, ], can_heat=True, can_stir=True,
-        layout=JuniorLayout.from_relative_layout("above", slot_2_3_1.layout)
+        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2", can_contain=[JuniorRack.get_rdf_type(), ], can_heat=True, can_stir=True,
+        layout=JuniorLayout.from_relative_layout("above", slot_2_3_1.layout.get_range_assume_one())
     )
     slot_2_3_3 = JuniorSlot(
-        identifier="SLOT 2-3-3", can_contain=[JuniorRack.__name__, ], can_heat=True, can_stir=True,
-        layout=JuniorLayout.from_relative_layout("above", slot_2_3_2.layout)
+        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3", can_contain=[JuniorRack.get_rdf_type(), ], can_heat=True, can_stir=True,
+        layout=JuniorLayout.from_relative_layout("above", slot_2_3_2.layout.get_range_assume_one())
     )
 
     slot_pdt_1 = JuniorSlot(
-        identifier="PDT SLOT 1", can_contain=[JuniorPdp.__name__, ],
-        layout=JuniorLayout.from_relative_layout("right_to", slot_2_3_1.layout, JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+        identifier=f"{JuniorOntology.get_namespace_iri()}/PDT-SLOT-1", can_contain=[JuniorPdp.get_rdf_type(), ],
+        layout=JuniorLayout.from_relative_layout("right_to", slot_2_3_1.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
     )
     slot_pdt_2 = JuniorSlot(
-        identifier="PDT SLOT 2", can_contain=[JuniorPdp.__name__, ],
-        layout=JuniorLayout.from_relative_layout("above", slot_pdt_1.layout, JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+        identifier=f"{JuniorOntology.get_namespace_iri()}/PDT-SLOT-2", can_contain=[JuniorPdp.get_rdf_type(), ],
+        layout=JuniorLayout.from_relative_layout("above", slot_pdt_1.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
     )
     slot_pdt_3 = JuniorSlot(
-        identifier="PDT SLOT 3", can_contain=[JuniorPdp.__name__, ],
-        layout=JuniorLayout.from_relative_layout("above", slot_pdt_2.layout, JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+        identifier=f"{JuniorOntology.get_namespace_iri()}/PDT-SLOT-3", can_contain=[JuniorPdp.get_rdf_type(), ],
+        layout=JuniorLayout.from_relative_layout("above", slot_pdt_2.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
     )
 
@@ -103,8 +103,8 @@ def create_junior_base():
         icol = i % num_sv_vial_per_row
         if i == 0:
             sv_vial_slot = JuniorSlot(
-                identifier=f"SVV SLOT {i + 1}", can_contain=[JuniorVial.__name__, ],
-                layout=JuniorLayout.from_relative_layout('above', slot_pdt_3.layout,
+                identifier=f"{JuniorOntology.get_namespace_iri()}/SVV-SLOT-{i + 1}", can_contain=[JuniorVial.get_rdf_type(), ],
+                layout=JuniorLayout.from_relative_layout('above', slot_pdt_3.layout.get_range_assume_one(),
                                                          JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                          JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
             )
@@ -117,64 +117,65 @@ def create_junior_base():
                 relation = "above"
                 relative = sv_vial_slots[i - num_sv_vial_per_row]
             sv_vial_slot = JuniorSlot(
-                identifier=f"SVV SLOT {i + 1}", can_contain=[JuniorVial.__name__, ],
-                layout=JuniorLayout.from_relative_layout(relation, relative.layout, JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+                identifier=f"{JuniorOntology.get_namespace_iri()}/SVV-SLOT-{i + 1}", can_contain=[JuniorVial.get_rdf_type(), ],
+                layout=JuniorLayout.from_relative_layout(relation, relative.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                          JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
             )
         sv_vial_slots.append(sv_vial_slot)
 
     sv_tool_slot = JuniorSlot(
-        identifier="SV TOOL SLOT", can_contain=[JuniorSvt.__name__, ],
-        layout=JuniorLayout.from_relative_layout('above', sv_vial_slots[9].layout),
+        identifier=f"{JuniorOntology.get_namespace_iri()}/SV-TOOL-SLOT", can_contain=[JuniorSvt.get_rdf_type(), ],
+        layout=JuniorLayout.from_relative_layout('above', sv_vial_slots[9].layout.get_range_assume_one()),
     )
 
     balance = JuniorSlot(
-        identifier="BALANCE SLOT", can_contain=[JuniorRack.__name__, ], can_weigh=True,
-        layout=JuniorLayout.from_relative_layout('right_to', sv_tool_slot.layout),
+        identifier=f"{JuniorOntology.get_namespace_iri()}/BALANCE-SLOT", can_contain=[JuniorRack.get_rdf_type(), ], can_weigh=True,
+        layout=JuniorLayout.from_relative_layout('right_to', sv_tool_slot.layout.get_range_assume_one()),
     )
 
     vpg_slot = JuniorSlot(
-        identifier="VPG SLOT", can_contain=[JuniorVpg.__name__, ],
-        layout=JuniorLayout.from_relative_layout('right_to', balance.layout, )
+        identifier=f"{JuniorOntology.get_namespace_iri()}/VPG-SLOT", can_contain=[JuniorVpg.get_rdf_type(), ],
+        layout=JuniorLayout.from_relative_layout('right_to', balance.layout.get_range_assume_one(), )
     )
 
     tip_disposal = JuniorTipDisposal(
-        identifier="DISPOSAL",
-        layout=JuniorLayout.from_relative_layout('right_to', vpg_slot.layout, layout_x=JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL)
+        identifier=f"{JuniorOntology.get_namespace_iri()}/DISPOSAL",
+        layout=JuniorLayout.from_relative_layout('right_to', vpg_slot.layout.get_range_assume_one(), layout_x=JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL)
     )
 
     arm_z1 = JuniorArmZ1(
-        identifier='Z1 ARM', contained_by='ARM PLATFORM', contained_in_slot="z1",
-        can_contain=[JuniorZ1Needle.__name__, ],
-        slot_content={
-            str(i + 1): JuniorZ1Needle(identifier=f"Z1 Needle {i + 1}", contained_by='Z1 ARM',
-                                       contained_in_slot=str(i + 1), material="STEEL").identifier for i in range(7)
-        },
+        identifier=f'{JuniorOntology.get_namespace_iri()}/Z1-ARM', contained_by=f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM', contained_in_slot="z1",
+        can_contain=[JuniorZ1Needle.get_rdf_type(), ],
+        has_slot_content=[
+            JuniorZ1Needle(identifier=f"{JuniorOntology.get_namespace_iri()}/Z1-Needle-{i + 1}", contained_by=f'{JuniorOntology.get_namespace_iri()}/Z1-ARM',
+                           contained_in_slot=str(i + 1), material="STEEL") for i in range(7)
+        ],
     )
 
     arm_z2 = JuniorArmZ2(
-        identifier='Z2 ARM', contained_by='ARM PLATFORM', contained_in_slot='z2',
-        can_contain=[JuniorSvt.__name__, JuniorVpg.__name__, JuniorPdp.__name__, ],
+        identifier=f'{JuniorOntology.get_namespace_iri()}/Z2-ARM', contained_by=f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM', contained_in_slot='z2',
+        can_contain=[JuniorSvt.get_rdf_type(), JuniorVpg.get_rdf_type(), JuniorPdp.get_rdf_type(), ],
     )
 
     arm_platform = JuniorArmPlatform(
-        identifier='ARM PLATFORM', can_contain=[JuniorArmZ1.__name__, JuniorArmZ2.__name__, ],
-        position_on_top_of=slot_off_1.identifier, anchor_arm=arm_z1.identifier,
-        slot_content={"z1": arm_z1.identifier, "z2": arm_z2.identifier},
+        identifier=f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM', can_contain=[JuniorArmZ1.get_rdf_type(), JuniorArmZ2.get_rdf_type(), ],
+        has_position_on_top_of=slot_off_1.identifier, has_anchor_arm=arm_z1.identifier,
+        has_slot_content=[arm_z1, arm_z2],
     )
 
-    sv_tool = JuniorSvt(identifier="SV TOOL", contained_by=sv_tool_slot.identifier, powder_param_known=False)
-    sv_tool_slot.slot_content['SLOT'] = sv_tool.identifier
+    sv_tool = JuniorSvt(identifier=f"{JuniorOntology.get_namespace_iri()}/SV-TOOL", contained_by=sv_tool_slot.identifier, powder_param_known=False,
+                        contained_in_slot='SLOT')
+    sv_tool_slot.has_slot_content.range.add(sv_tool)
 
-    vpg = JuniorVpg(identifier="VPG", contained_by=vpg_slot.identifier)
-    vpg_slot.slot_content['SLOT'] = vpg.identifier
+    vpg = JuniorVpg(identifier=f"{JuniorOntology.get_namespace_iri()}/VPG", contained_by=vpg_slot.identifier, contained_in_slot='SLOT')
+    vpg_slot.has_slot_content.range.add(vpg)
 
-    pdp_1 = JuniorPdp(identifier='PDT 1', contained_by=slot_pdt_1.identifier)
-    pdp_2 = JuniorPdp(identifier='PDT 2', contained_by=slot_pdt_2.identifier)
-    pdp_3 = JuniorPdp(identifier='PDT 3', contained_by=slot_pdt_3.identifier)
-    slot_pdt_1.slot_content['SLOT'] = pdp_1.identifier
-    slot_pdt_2.slot_content['SLOT'] = pdp_2.identifier
-    slot_pdt_3.slot_content['SLOT'] = pdp_3.identifier
+    pdp_1 = JuniorPdp(identifier=f'{JuniorOntology.get_namespace_iri()}/PDT-1', contained_by=slot_pdt_1.identifier, contained_in_slot='SLOT')
+    pdp_2 = JuniorPdp(identifier=f'{JuniorOntology.get_namespace_iri()}/PDT-2', contained_by=slot_pdt_2.identifier, contained_in_slot='SLOT')
+    pdp_3 = JuniorPdp(identifier=f'{JuniorOntology.get_namespace_iri()}/PDT-3', contained_by=slot_pdt_3.identifier, contained_in_slot='SLOT')
+    slot_pdt_1.has_slot_content.range.add(pdp_1)
+    slot_pdt_2.has_slot_content.range.add(pdp_2)
+    slot_pdt_3.has_slot_content.range.add(pdp_3)
 
     return JuniorBenchtop(
         SLOT_OFF_1=slot_off_1,

--- a/hardware_pydantic/junior/junior_lab.py
+++ b/hardware_pydantic/junior/junior_lab.py
@@ -3,7 +3,7 @@ from hardware_pydantic.junior.settings import *
 
 
 class JuniorBenchtop(BaseClass):
-    is_defined_by_ontology = JuniorOntology
+    rdfs_isDefinedBy = JuniorOntology
     SLOT_OFF_1: JuniorSlot
     SLOT_OFF_2: JuniorSlot
     SLOT_OFF_3: JuniorSlot
@@ -47,50 +47,50 @@ def create_junior_base():
     assert len(JUNIOR_LAB.dict_object) == 0, "JUNIOR BASE HAS ALREADY BEEN INIT!!!"
 
     slot_off_1 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1", can_contain=[JuniorRack.get_rdf_type(), ],
+        identifier=f"{JuniorOntology.namespace_iri}/SLOT-OFF-1", can_contain=[JuniorRack.rdf_type, ],
         layout=JuniorLayout.from_relative_layout()
     )
     slot_off_2 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-OFF-2", can_contain=[JuniorRack.get_rdf_type(), ],
-        layout=JuniorLayout.from_relative_layout("above", slot_off_1.layout.get_range_assume_one())
+        identifier=f"{JuniorOntology.namespace_iri}/SLOT-OFF-2", can_contain=[JuniorRack.rdf_type, ],
+        layout=JuniorLayout.from_relative_layout("above", list(slot_off_1.layout)[0])
     )
     slot_off_3 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-OFF-3", can_contain=[JuniorRack.get_rdf_type(), ],
-        layout=JuniorLayout.from_relative_layout("above", slot_off_2.layout.get_range_assume_one())
+        identifier=f"{JuniorOntology.namespace_iri}/SLOT-OFF-3", can_contain=[JuniorRack.rdf_type, ],
+        layout=JuniorLayout.from_relative_layout("above", list(slot_off_2.layout)[0])
     )
 
     wash_bay = JuniorWashBay(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/WASH-BAY",
-        layout=JuniorLayout.from_relative_layout("right_to", slot_off_1.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL,
+        identifier=f"{JuniorOntology.namespace_iri}/WASH-BAY",
+        layout=JuniorLayout.from_relative_layout("right_to", list(slot_off_1.layout)[0], JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y * 3)
     )
 
     slot_2_3_1 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1", can_contain=[JuniorRack.get_rdf_type(), ], can_heat=True, can_cool=True, can_stir=True,
-        layout=JuniorLayout.from_relative_layout("right_to", wash_bay.layout.get_range_assume_one())
+        identifier=f"{JuniorOntology.namespace_iri}/SLOT-2-3-1", can_contain=[JuniorRack.rdf_type, ], can_heat=True, can_cool=True, can_stir=True,
+        layout=JuniorLayout.from_relative_layout("right_to", list(wash_bay.layout)[0])
     )
     slot_2_3_2 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2", can_contain=[JuniorRack.get_rdf_type(), ], can_heat=True, can_stir=True,
-        layout=JuniorLayout.from_relative_layout("above", slot_2_3_1.layout.get_range_assume_one())
+        identifier=f"{JuniorOntology.namespace_iri}/SLOT-2-3-2", can_contain=[JuniorRack.rdf_type, ], can_heat=True, can_stir=True,
+        layout=JuniorLayout.from_relative_layout("above", list(slot_2_3_1.layout)[0])
     )
     slot_2_3_3 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3", can_contain=[JuniorRack.get_rdf_type(), ], can_heat=True, can_stir=True,
-        layout=JuniorLayout.from_relative_layout("above", slot_2_3_2.layout.get_range_assume_one())
+        identifier=f"{JuniorOntology.namespace_iri}/SLOT-2-3-3", can_contain=[JuniorRack.rdf_type, ], can_heat=True, can_stir=True,
+        layout=JuniorLayout.from_relative_layout("above", list(slot_2_3_2.layout)[0])
     )
 
     slot_pdt_1 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/PDT-SLOT-1", can_contain=[JuniorPdp.get_rdf_type(), ],
-        layout=JuniorLayout.from_relative_layout("right_to", slot_2_3_1.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+        identifier=f"{JuniorOntology.namespace_iri}/PDT-SLOT-1", can_contain=[JuniorPdp.rdf_type, ],
+        layout=JuniorLayout.from_relative_layout("right_to", list(slot_2_3_1.layout)[0], JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
     )
     slot_pdt_2 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/PDT-SLOT-2", can_contain=[JuniorPdp.get_rdf_type(), ],
-        layout=JuniorLayout.from_relative_layout("above", slot_pdt_1.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+        identifier=f"{JuniorOntology.namespace_iri}/PDT-SLOT-2", can_contain=[JuniorPdp.rdf_type, ],
+        layout=JuniorLayout.from_relative_layout("above", list(slot_pdt_1.layout)[0], JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
     )
     slot_pdt_3 = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/PDT-SLOT-3", can_contain=[JuniorPdp.get_rdf_type(), ],
-        layout=JuniorLayout.from_relative_layout("above", slot_pdt_2.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+        identifier=f"{JuniorOntology.namespace_iri}/PDT-SLOT-3", can_contain=[JuniorPdp.rdf_type, ],
+        layout=JuniorLayout.from_relative_layout("above", list(slot_pdt_2.layout)[0], JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                  JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
     )
 
@@ -103,8 +103,8 @@ def create_junior_base():
         icol = i % num_sv_vial_per_row
         if i == 0:
             sv_vial_slot = JuniorSlot(
-                identifier=f"{JuniorOntology.get_namespace_iri()}/SVV-SLOT-{i + 1}", can_contain=[JuniorVial.get_rdf_type(), ],
-                layout=JuniorLayout.from_relative_layout('above', slot_pdt_3.layout.get_range_assume_one(),
+                identifier=f"{JuniorOntology.namespace_iri}/SVV-SLOT-{i + 1}", can_contain=[JuniorVial.rdf_type, ],
+                layout=JuniorLayout.from_relative_layout('above', list(slot_pdt_3.layout)[0],
                                                          JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                          JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
             )
@@ -117,65 +117,65 @@ def create_junior_base():
                 relation = "above"
                 relative = sv_vial_slots[i - num_sv_vial_per_row]
             sv_vial_slot = JuniorSlot(
-                identifier=f"{JuniorOntology.get_namespace_iri()}/SVV-SLOT-{i + 1}", can_contain=[JuniorVial.get_rdf_type(), ],
-                layout=JuniorLayout.from_relative_layout(relation, relative.layout.get_range_assume_one(), JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
+                identifier=f"{JuniorOntology.namespace_iri}/SVV-SLOT-{i + 1}", can_contain=[JuniorVial.rdf_type, ],
+                layout=JuniorLayout.from_relative_layout(relation, list(relative.layout)[0], JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL * 2,
                                                          JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL),
             )
         sv_vial_slots.append(sv_vial_slot)
 
     sv_tool_slot = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/SV-TOOL-SLOT", can_contain=[JuniorSvt.get_rdf_type(), ],
-        layout=JuniorLayout.from_relative_layout('above', sv_vial_slots[9].layout.get_range_assume_one()),
+        identifier=f"{JuniorOntology.namespace_iri}/SV-TOOL-SLOT", can_contain=[JuniorSvt.rdf_type, ],
+        layout=JuniorLayout.from_relative_layout('above', list(sv_vial_slots[9].layout)[0]),
     )
 
     balance = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/BALANCE-SLOT", can_contain=[JuniorRack.get_rdf_type(), ], can_weigh=True,
-        layout=JuniorLayout.from_relative_layout('right_to', sv_tool_slot.layout.get_range_assume_one()),
+        identifier=f"{JuniorOntology.namespace_iri}/BALANCE-SLOT", can_contain=[JuniorRack.rdf_type, ], can_weigh=True,
+        layout=JuniorLayout.from_relative_layout('right_to', list(sv_tool_slot.layout)[0]),
     )
 
     vpg_slot = JuniorSlot(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/VPG-SLOT", can_contain=[JuniorVpg.get_rdf_type(), ],
-        layout=JuniorLayout.from_relative_layout('right_to', balance.layout.get_range_assume_one(), )
+        identifier=f"{JuniorOntology.namespace_iri}/VPG-SLOT", can_contain=[JuniorVpg.rdf_type, ],
+        layout=JuniorLayout.from_relative_layout('right_to', list(balance.layout)[0], )
     )
 
     tip_disposal = JuniorTipDisposal(
-        identifier=f"{JuniorOntology.get_namespace_iri()}/DISPOSAL",
-        layout=JuniorLayout.from_relative_layout('right_to', vpg_slot.layout.get_range_assume_one(), layout_x=JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL)
+        identifier=f"{JuniorOntology.namespace_iri}/DISPOSAL",
+        layout=JuniorLayout.from_relative_layout('right_to', list(vpg_slot.layout)[0], layout_x=JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL)
     )
 
     arm_z1 = JuniorArmZ1(
-        identifier=f'{JuniorOntology.get_namespace_iri()}/Z1-ARM', contained_by=f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM', contained_in_slot="z1",
-        can_contain=[JuniorZ1Needle.get_rdf_type(), ],
+        identifier=f'{JuniorOntology.namespace_iri}/Z1-ARM', contained_by=f'{JuniorOntology.namespace_iri}/ARM-PLATFORM', contained_in_slot="z1",
+        can_contain=[JuniorZ1Needle.rdf_type, ],
         has_slot_content=[
-            JuniorZ1Needle(identifier=f"{JuniorOntology.get_namespace_iri()}/Z1-Needle-{i + 1}", contained_by=f'{JuniorOntology.get_namespace_iri()}/Z1-ARM',
+            JuniorZ1Needle(identifier=f"{JuniorOntology.namespace_iri}/Z1-Needle-{i + 1}", contained_by=f'{JuniorOntology.namespace_iri}/Z1-ARM',
                            contained_in_slot=str(i + 1), material="STEEL") for i in range(7)
         ],
     )
 
     arm_z2 = JuniorArmZ2(
-        identifier=f'{JuniorOntology.get_namespace_iri()}/Z2-ARM', contained_by=f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM', contained_in_slot='z2',
-        can_contain=[JuniorSvt.get_rdf_type(), JuniorVpg.get_rdf_type(), JuniorPdp.get_rdf_type(), ],
+        identifier=f'{JuniorOntology.namespace_iri}/Z2-ARM', contained_by=f'{JuniorOntology.namespace_iri}/ARM-PLATFORM', contained_in_slot='z2',
+        can_contain=[JuniorSvt.rdf_type, JuniorVpg.rdf_type, JuniorPdp.rdf_type, ],
     )
 
     arm_platform = JuniorArmPlatform(
-        identifier=f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM', can_contain=[JuniorArmZ1.get_rdf_type(), JuniorArmZ2.get_rdf_type(), ],
+        identifier=f'{JuniorOntology.namespace_iri}/ARM-PLATFORM', can_contain=[JuniorArmZ1.rdf_type, JuniorArmZ2.rdf_type, ],
         has_position_on_top_of=slot_off_1.identifier, has_anchor_arm=arm_z1.identifier,
         has_slot_content=[arm_z1, arm_z2],
     )
 
-    sv_tool = JuniorSvt(identifier=f"{JuniorOntology.get_namespace_iri()}/SV-TOOL", contained_by=sv_tool_slot.identifier, powder_param_known=False,
+    sv_tool = JuniorSvt(identifier=f"{JuniorOntology.namespace_iri}/SV-TOOL", contained_by=sv_tool_slot.identifier, powder_param_known=False,
                         contained_in_slot='SLOT')
-    sv_tool_slot.has_slot_content.range.add(sv_tool)
+    sv_tool_slot.has_slot_content.add(sv_tool)
 
-    vpg = JuniorVpg(identifier=f"{JuniorOntology.get_namespace_iri()}/VPG", contained_by=vpg_slot.identifier, contained_in_slot='SLOT')
-    vpg_slot.has_slot_content.range.add(vpg)
+    vpg = JuniorVpg(identifier=f"{JuniorOntology.namespace_iri}/VPG", contained_by=vpg_slot.identifier, contained_in_slot='SLOT')
+    vpg_slot.has_slot_content.add(vpg)
 
-    pdp_1 = JuniorPdp(identifier=f'{JuniorOntology.get_namespace_iri()}/PDT-1', contained_by=slot_pdt_1.identifier, contained_in_slot='SLOT')
-    pdp_2 = JuniorPdp(identifier=f'{JuniorOntology.get_namespace_iri()}/PDT-2', contained_by=slot_pdt_2.identifier, contained_in_slot='SLOT')
-    pdp_3 = JuniorPdp(identifier=f'{JuniorOntology.get_namespace_iri()}/PDT-3', contained_by=slot_pdt_3.identifier, contained_in_slot='SLOT')
-    slot_pdt_1.has_slot_content.range.add(pdp_1)
-    slot_pdt_2.has_slot_content.range.add(pdp_2)
-    slot_pdt_3.has_slot_content.range.add(pdp_3)
+    pdp_1 = JuniorPdp(identifier=f'{JuniorOntology.namespace_iri}/PDT-1', contained_by=slot_pdt_1.identifier, contained_in_slot='SLOT')
+    pdp_2 = JuniorPdp(identifier=f'{JuniorOntology.namespace_iri}/PDT-2', contained_by=slot_pdt_2.identifier, contained_in_slot='SLOT')
+    pdp_3 = JuniorPdp(identifier=f'{JuniorOntology.namespace_iri}/PDT-3', contained_by=slot_pdt_3.identifier, contained_in_slot='SLOT')
+    slot_pdt_1.has_slot_content.add(pdp_1)
+    slot_pdt_2.has_slot_content.add(pdp_2)
+    slot_pdt_3.has_slot_content.add(pdp_3)
 
     return JuniorBenchtop(
         SLOT_OFF_1=slot_off_1,

--- a/hardware_pydantic/junior/junior_objects.py
+++ b/hardware_pydantic/junior/junior_objects.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from hardware_pydantic.junior.settings import JUNIOR_LAB, JuniorLabObject, JUNIOR_VIAL_TYPE, JuniorLayout, Layout
 from hardware_pydantic.lab_objects import ChemicalContainer, LabContainee, LabContainer, Can_contain
-from hardware_pydantic.base import JuniorOntology, Material
+from hardware_pydantic.base import JuniorOntology, Material, LabObject
 
-from twa.data_model.base_ontology import DatatypeProperty, as_range
+from twa.data_model.base_ontology import DatatypeProperty
 
 """"Lab objects for the JUNIOR platform from NCATS."""
 
 class Is_spinning(DatatypeProperty):
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(bool)
+    rdfs_isDefinedBy = JuniorOntology
 
 class JuniorStirBar(LabContainee, JuniorLabObject):
     """A stir bar that can be placed in a vial.
@@ -23,9 +24,9 @@ class JuniorStirBar(LabContainee, JuniorLabObject):
         Whether the stir bar is spinning. Default is False.
 
     """
-    material: Material = Material(range="TEFLON")
+    material: Material[str] = "TEFLON"
 
-    is_spinning: Is_spinning = Is_spinning(range=False)
+    is_spinning: Is_spinning[bool] = False
 
 
 class JuniorVial(ChemicalContainer, LabContainee, LabContainer, JuniorLabObject):
@@ -40,7 +41,7 @@ class JuniorVial(ChemicalContainer, LabContainee, LabContainer, JuniorLabObject)
 
     """
 
-    can_contain: Can_contain = Can_contain(range=[JuniorStirBar.get_rdf_type(), ])
+    can_contain: Can_contain[LabObject] = [JuniorStirBar.rdf_type, ]
 
     vial_type: JUNIOR_VIAL_TYPE = "HRV"
 
@@ -54,7 +55,7 @@ class JuniorPdpTip(ChemicalContainer, LabContainee, JuniorLabObject):
         The material the tip is made of. Default is "PLASTIC".
 
     """
-    material: Material = Material(range="PLASTIC")
+    material: Material[str] = "PLASTIC"
 
 
 class JuniorRack(LabContainer, LabContainee, JuniorLabObject):
@@ -108,7 +109,7 @@ class JuniorRack(LabContainer, LabContainee, JuniorLabObject):
                 v = JuniorVial(
                     contained_by=rack.identifier, contained_in_slot=idx,
                 )
-            rack.has_slot_content.range.add(v)
+            rack.has_slot_content.add(v)
             tips.append(v)
             n_created += 1
             if n_created == n_tips:
@@ -166,7 +167,7 @@ class JuniorRack(LabContainer, LabContainee, JuniorLabObject):
                 v = JuniorVial(
                     contained_by=rack.identifier, contained_in_slot=idx, vial_type=vial_type,
                 )
-            rack.has_slot_content.range.add(v)
+            rack.has_slot_content.add(v)
             vials.append(v)
             n_created += 1
             if n_created == n_vials:
@@ -184,7 +185,7 @@ class JuniorVpg(LabContainee, LabContainer, JuniorLabObject):
 
     """
 
-    can_contain: Can_contain = Can_contain(range=[JuniorRack.get_rdf_type(), ])
+    can_contain: Can_contain[LabObject] = [JuniorRack.rdf_type, ]
 
     @property
     def rack(self) -> JuniorRack | None:
@@ -213,7 +214,7 @@ class JuniorPdp(LabContainee, LabContainer, JuniorLabObject):
         strings containing the name of the positive displacement pipette tip.
     """
 
-    can_contain: Can_contain = Can_contain(range=[JuniorPdpTip.get_rdf_type(), ])
+    can_contain: Can_contain[LabObject] = [JuniorPdpTip.rdf_type, ]
 
     @property
     def tip(self) -> JuniorPdpTip | None:
@@ -232,8 +233,7 @@ class JuniorPdp(LabContainee, LabContainer, JuniorLabObject):
 
 
 class Powder_param_known(DatatypeProperty):
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(bool)
+    rdfs_isDefinedBy = JuniorOntology
 
 class JuniorSvt(LabContainee, LabContainer, JuniorLabObject):
     """The SV tool which is the z2 attachment used to hold a SV vial.
@@ -248,9 +248,9 @@ class JuniorSvt(LabContainee, LabContainer, JuniorLabObject):
 
     """
 
-    can_contain: Can_contain = Can_contain(range=[JuniorVial.get_rdf_type(), ])
+    can_contain: Can_contain[LabObject] = [JuniorVial.rdf_type, ]
 
-    powder_param_known: Powder_param_known = Powder_param_known(range=False)
+    powder_param_known: Powder_param_known[bool] = False
 
     @property
     def sv_vial(self) -> JuniorVial | None:
@@ -282,13 +282,12 @@ class JuniorWashBay(JuniorLabObject):
         The layout of the wash bay. Default is None.
 
     """
-    layout: Layout
+    layout: Layout[JuniorLayout]
 
 
 class Disposal_content(DatatypeProperty):
     # TODO should be an object property
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(str)
+    rdfs_isDefinedBy = JuniorOntology
 
 class JuniorTipDisposal(JuniorLabObject):
     """The tip disposal for used PdpTips.
@@ -301,9 +300,9 @@ class JuniorTipDisposal(JuniorLabObject):
         The list of objects that can be disposed of in the tip disposal. Default is an empty list.
 
     """
-    layout: Layout
+    layout: Layout[JuniorLayout]
 
-    disposal_content: Disposal_content
+    disposal_content: Optional[Disposal_content[str]] = set()
 
 
 """python

--- a/hardware_pydantic/junior/junior_objects.py
+++ b/hardware_pydantic/junior/junior_objects.py
@@ -90,7 +90,7 @@ class JuniorRack(LabContainer, LabContainee, JuniorLabObject):
 
         """
         rack = JuniorRack.from_capacity(
-            can_contain=[JuniorPdpTip.__name__, ], capacity=rack_capacity, container_id=rack_id
+            can_contain=[JuniorPdpTip.rdf_type, ], capacity=rack_capacity, container_id=rack_id
         )
 
         assert n_tips <= rack.slot_capacity, f"{n_tips} {rack.slot_capacity}"
@@ -149,7 +149,7 @@ class JuniorRack(LabContainer, LabContainee, JuniorLabObject):
         """
 
         rack = JuniorRack.from_capacity(
-            can_contain=[JuniorVial.__name__, ], capacity=rack_capacity, container_id=rack_id
+            can_contain=[JuniorVial.rdf_type, ], capacity=rack_capacity, container_id=rack_id
         )
 
         assert n_vials <= rack.slot_capacity, f"{n_vials} {rack.slot_capacity}"

--- a/hardware_pydantic/junior/settings.py
+++ b/hardware_pydantic/junior/settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal, ClassVar, Type
 
 from hardware_pydantic.base import Lab, LabObject, Instruction, JuniorOntology
-from twa.data_model.base_ontology import BaseClass, BaseOntology, ObjectProperty, DatatypeProperty, as_range
+from twa.data_model.base_ontology import BaseClass, BaseOntology, ObjectProperty, DatatypeProperty
 
 JUNIOR_LAYOUT_SLOT_SIZE_X = 80
 JUNIOR_LAYOUT_SLOT_SIZE_Y = 120
@@ -34,23 +34,19 @@ class JuniorInstruction(Instruction):
     def path_graph(ins_list: list[JuniorInstruction]):
         for i in range(1, len(ins_list)):
             ins = ins_list[i]
-            ins.preceding_instructions.range.add(ins_list[i-1].identifier)
+            ins.preceding_instructions.add(ins_list[i-1].identifier)
 
 class Layout_x(DatatypeProperty):
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(float)
+    rdfs_isDefinedBy = JuniorOntology
 
 class Layout_y(DatatypeProperty):
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(float)
+    rdfs_isDefinedBy = JuniorOntology
 
 class Absolute_layout_position_x(DatatypeProperty):
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(float)
+    rdfs_isDefinedBy = JuniorOntology
 
 class Absolute_layout_position_y(DatatypeProperty):
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(float)
+    rdfs_isDefinedBy = JuniorOntology
 
 
 class JuniorLayout(BaseClass):
@@ -66,11 +62,11 @@ class JuniorLayout(BaseClass):
         The y length, Default is JUNIOR_LAYOUT_SLOT_SIZE_Y.
 
     """
-    is_defined_by_ontology = JuniorOntology
-    absolute_layout_position_x: Absolute_layout_position_x
-    absolute_layout_position_y: Absolute_layout_position_y
-    layout_x: Layout_x
-    layout_y: Layout_y
+    rdfs_isDefinedBy = JuniorOntology
+    absolute_layout_position_x: Absolute_layout_position_x[float]
+    absolute_layout_position_y: Absolute_layout_position_y[float]
+    layout_x: Layout_x[float]
+    layout_y: Layout_y[float]
 
     def __init__(self, **data):
         if 'layout_x' not in data:
@@ -86,8 +82,8 @@ class JuniorLayout(BaseClass):
     @property
     def layout_position(self):
         return tuple([
-            self.absolute_layout_position_x.get_range_assume_one(),
-            self.absolute_layout_position_y.get_range_assume_one()])
+            list(self.absolute_layout_position_x)[0],
+            list(self.absolute_layout_position_y)[0]])
 
     @classmethod
     def from_relative_layout(
@@ -122,9 +118,9 @@ class JuniorLayout(BaseClass):
         else:
             if layout_relation == "above":
                 absolute_layout_position_x = layout_relative.layout_position[0]
-                absolute_layout_position_y = layout_relative.layout_position[1] + layout_relative.layout_y.get_range_assume_one() + 20
+                absolute_layout_position_y = layout_relative.layout_position[1] + list(layout_relative.layout_y)[0] + 20
             elif layout_relation == "right_to":
-                absolute_layout_position_x = layout_relative.layout_position[0] + layout_relative.layout_x.get_range_assume_one() + 20
+                absolute_layout_position_x = layout_relative.layout_position[0] + list(layout_relative.layout_x)[0] + 20
                 absolute_layout_position_y = layout_relative.layout_position[1]
             else:
                 raise ValueError
@@ -136,5 +132,4 @@ class JuniorLayout(BaseClass):
         )
 
 class Layout(ObjectProperty):
-    is_defined_by_ontology = JuniorOntology
-    range: as_range(JuniorLayout)
+    rdfs_isDefinedBy = JuniorOntology

--- a/hardware_pydantic/junior/settings.py
+++ b/hardware_pydantic/junior/settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal, ClassVar, Type
 
 from hardware_pydantic.base import Lab, LabObject, Instruction, JuniorOntology
-from py4jps.data_model.base_ontology import BaseClass, BaseOntology
+from twa.data_model.base_ontology import BaseClass, BaseOntology
 
 JUNIOR_LAYOUT_SLOT_SIZE_X = 80
 JUNIOR_LAYOUT_SLOT_SIZE_Y = 120

--- a/hardware_pydantic/junior/settings.py
+++ b/hardware_pydantic/junior/settings.py
@@ -1,26 +1,33 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, ClassVar, Type
 
-from hardware_pydantic.base import Lab, LabObject, Instruction, BaseModel
+from hardware_pydantic.base import Lab, LabObject, Instruction, JuniorOntology
+from py4jps.data_model.base_ontology import BaseClass, BaseOntology
 
 JUNIOR_LAYOUT_SLOT_SIZE_X = 80
 JUNIOR_LAYOUT_SLOT_SIZE_Y = 120
 JUNIOR_LAYOUT_SLOT_SIZE_X_SMALL = 40
 JUNIOR_LAYOUT_SLOT_SIZE_Y_SMALL = 20
-JUNIOR_LAB = Lab()
+JUNIOR_LAB = Lab(example_data_property='this is an example data property.')
 JUNIOR_VIAL_TYPE = Literal["HRV", "MRV", "SV"]
 
 
 class JuniorLabObject(LabObject):
     """Base class for all Junior lab objects."""
     def model_post_init(self, *args) -> None:
+        # NOTE that the super().model_post_init() must be called to finalise the object creation
+        # and have the object registred in the knowledge graph
+        super().model_post_init(*args)
         JUNIOR_LAB.add_object(self)
 
 
 class JuniorInstruction(Instruction):
     """Base class for all Junior instructions."""
     def model_post_init(self, *args) -> None:
+        # NOTE that the super().model_post_init() must be called to finalise the object creation
+        # and have the object registred in the knowledge graph
+        super().model_post_init(*args)
         JUNIOR_LAB.add_instruction(self)
 
     @staticmethod
@@ -30,7 +37,7 @@ class JuniorInstruction(Instruction):
             ins.preceding_instructions.append(ins_list[i-1].identifier)
 
 
-class JuniorLayout(BaseModel):
+class JuniorLayout(BaseClass):
     """A region appears in layout.
 
     Parameters
@@ -43,6 +50,7 @@ class JuniorLayout(BaseModel):
         The y length, Default is JUNIOR_LAYOUT_SLOT_SIZE_Y.
 
     """
+    is_defined_by_ontology: ClassVar[Type[BaseOntology]] = JuniorOntology
     layout_position: tuple[float, float] | None = None
     layout_x: float = JUNIOR_LAYOUT_SLOT_SIZE_X
     layout_y: float = JUNIOR_LAYOUT_SLOT_SIZE_Y

--- a/hardware_pydantic/lab_objects.py
+++ b/hardware_pydantic/lab_objects.py
@@ -53,6 +53,10 @@ class ChemicalContainer(LabObject):
     def chemical_content(self) -> dict[str, float]:
         return {list(c.chemical_name)[0]: list(c.amount)[0] for c in self.has_chemical_content}
 
+    @chemical_content.setter
+    def chemical_content(self, content: dict[str, float]):
+        self.add_content(content)
+
     @property
     def content_sum(self) -> float:
         if len(self.chemical_content) == 0:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_namespace_packages
+
+setup(
+    name='simulator_aspire',
+    version='0.0.1',
+    author='',
+    author_email='',
+    license='MIT',
+    python_requires='>=3.10',
+    description="",
+    url="",
+    long_description=open('readme.md').read(),
+    long_description_content_type="text/markdown",
+    packages=find_namespace_packages(exclude=['tests','tests.*']),
+    install_requires=['rdkit', 'rdflib', 'py4jps>=1.41.1a0'],
+    include_package_data=True
+)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     long_description=open('readme.md').read(),
     long_description_content_type="text/markdown",
     packages=find_namespace_packages(exclude=['tests','tests.*']),
-    install_requires=['rdkit', 'rdflib', 'py4jps>=1.41.1a0'],
+    install_requires=['rdkit', 'rdflib', 'twa>=0.0.2a0'],
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     long_description=open('readme.md').read(),
     long_description_content_type="text/markdown",
     packages=find_namespace_packages(exclude=['tests','tests.*']),
-    install_requires=['rdkit', 'rdflib', 'twa>=0.0.2a0'],
+    install_requires=['rdkit', 'rdflib', 'twa>=0.0.3'],
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     long_description=open('readme.md').read(),
     long_description_content_type="text/markdown",
     packages=find_namespace_packages(exclude=['tests','tests.*']),
-    install_requires=['rdkit', 'rdflib', 'twa>=0.0.3'],
+    install_requires=['rdkit', 'rdflib', 'twa>=0.0.4a0'],
     include_package_data=True
 )

--- a/sim_junior/sim_junior.py
+++ b/sim_junior/sim_junior.py
@@ -503,3 +503,12 @@ env = simpy.Environment()
 model = Model(env, JUNIOR_LAB, wdir=os.path.abspath("./"), model_name=f"con-{CONCURRENCY}")
 
 env.run()
+
+JuniorOntology.export_to_owl("junior_lab_tbox.ttl")
+print("TBox exported to junior_lab_tbox.ttl")
+from rdflib import Graph
+g2r = Graph()
+g2a = Graph()
+g2r, g2a = JUNIOR_LAB.collect_diff_to_graph(g2r, g2a, -1)
+g2a.serialize(destination="junior_lab_abox.ttl", format="turtle")
+print("ABox exported to junior_lab_abox.ttl")

--- a/sim_junior/sim_junior.py
+++ b/sim_junior/sim_junior.py
@@ -11,66 +11,66 @@ CONCURRENCY = 1
 
 # RACK A: holding HRVs with DCM, on off deck initially
 RACK_A, RACK_A_VIALS = JuniorRack.create_rack_with_empty_vials(
-    n_vials=CONCURRENCY, rack_capacity=6, vial_type="HRV", rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-A"
+    n_vials=CONCURRENCY, rack_capacity=6, vial_type="HRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK-A"
 )
 RACK_A: JuniorRack
 RACK_A_VIALS: list[JuniorVial]
 for v in RACK_A_VIALS:
     v.add_content({"DCM": 1000})
-JuniorSlot.put_rack_in_a_slot(RACK_A, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1'])
+JuniorSlot.put_rack_in_a_slot(RACK_A, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-OFF-1'])
 
 # RACK B: holding HRVs for reactions, at 2-3-2 initially, one for RSO2Cl stock solution, another for pyridine source
 RACK_B, RACK_B_VIALS = JuniorRack.create_rack_with_empty_vials(
-    n_vials=CONCURRENCY + 1, rack_capacity=8, vial_type="HRV", rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-B"
+    n_vials=CONCURRENCY + 1, rack_capacity=8, vial_type="HRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK-B"
 )
 RACK_B: JuniorRack
 RACK_B_VIALS: list[JuniorVial]
-JuniorSlot.put_rack_in_a_slot(RACK_B, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'])
+JuniorSlot.put_rack_in_a_slot(RACK_B, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'])
 
 # RACK C: holding one MRV for reaction, at 2-3-1 initially
 RACK_C, RACK_C_VIALS = JuniorRack.create_rack_with_empty_vials(
-    n_vials=CONCURRENCY, rack_capacity=6, vial_type="MRV", rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-C"
+    n_vials=CONCURRENCY, rack_capacity=6, vial_type="MRV", rack_id=f"{JuniorOntology.namespace_iri}/RACK-C"
 )
 RACK_C: JuniorRack
 RACK_C_VIALS: list[JuniorVial]
-JuniorSlot.put_rack_in_a_slot(RACK_C, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'])
+JuniorSlot.put_rack_in_a_slot(RACK_C, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'])
 
 # RACK D: holding PDP tips, at 2-3-3 initially
 RACK_D, RACK_D_TIPS = JuniorRack.create_rack_with_empty_tips(
-    n_tips=CONCURRENCY, rack_capacity=6, rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-D", tip_id_inherit=True
+    n_tips=CONCURRENCY, rack_capacity=6, rack_id=f"{JuniorOntology.namespace_iri}/RACK-D", tip_id_inherit=True
 )
 RACK_D: JuniorRack
 RACK_D_TIPS: list[JuniorPdpTip]
-JuniorSlot.put_rack_in_a_slot(RACK_D, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'])
+JuniorSlot.put_rack_in_a_slot(RACK_D, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-3'])
 
 # SV VIALS, one for solid amine (aniline), another for RSO2Cl, each sits in a SVV SLOT
 SVV_1 = JuniorVial(
-    identifier=f"{JuniorOntology.get_namespace_iri()}/SV-VIAL-1", contained_by=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-1'].identifier,
+    identifier=f"{JuniorOntology.namespace_iri}/SV-VIAL-1", contained_by=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SVV-SLOT-1'].identifier,
     vial_type='SV', contained_in_slot='SLOT'
 )
 SVV_1.add_content({"solid amine": 1000})
 SVV_2 = JuniorVial(
-    identifier=f"{JuniorOntology.get_namespace_iri()}/SV-VIAL-2", contained_by=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-2'].identifier,
+    identifier=f"{JuniorOntology.namespace_iri}/SV-VIAL-2", contained_by=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SVV-SLOT-2'].identifier,
     vial_type='SV', contained_in_slot='SLOT'
 )
 SVV_2.add_content({'sulfonyl chloride': 1000})
-JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-1'].has_slot_content.range.add(SVV_1)
-JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-2'].has_slot_content.range.add(SVV_2)
+JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SVV-SLOT-1'].has_slot_content.add(SVV_1)
+JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SVV-SLOT-2'].has_slot_content.add(SVV_2)
 
 # INSTRUCTIONS
-Z1_ARM = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/Z1-ARM']
-Z2_ARM = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/Z2-ARM']
-ARM_PLATFORM = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM']
+Z1_ARM = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/Z1-ARM']
+Z2_ARM = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/Z2-ARM']
+ARM_PLATFORM = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/ARM-PLATFORM']
 
-Z1NEEDLES = [JUNIOR_LAB[f"{JuniorOntology.get_namespace_iri()}/Z1-Needle-{i + 1}"] for i in range(CONCURRENCY)]
+Z1NEEDLES = [JUNIOR_LAB[f"{JuniorOntology.namespace_iri}/Z1-Needle-{i + 1}"] for i in range(CONCURRENCY)]
 
-VPG = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/VPG']
-VPG_SLOT = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/VPG-SLOT']
-SV_TOOL = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SV-TOOL']
-SV_TOOL_SLOT = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SV-TOOL-SLOT']
-BALANCE_SLOT = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/BALANCE-SLOT']
+VPG = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/VPG']
+VPG_SLOT = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/VPG-SLOT']
+SV_TOOL = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SV-TOOL']
+SV_TOOL_SLOT = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SV-TOOL-SLOT']
+BALANCE_SLOT = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/BALANCE-SLOT']
 
-PDP_1 = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/PDT-1']
+PDP_1 = JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/PDT-1']
 
 DCM_VIALS = RACK_A_VIALS
 MRV_VIALS = RACK_C_VIALS
@@ -308,14 +308,14 @@ def needle_dispense(
         send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z1_ARM,
-            "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/WASH-BAY'],
+            "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/WASH-BAY'],
         },
         description=f"move to slot: WASH BAY"
     )
     ins6 = JuniorInstruction(
         send_to_device=Z1_ARM, action_name="wash",
         action_parameters={
-            "wash_bay": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/WASH-BAY'],
+            "wash_bay": JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/WASH-BAY'],
         },
         description="wash needles"
     )
@@ -335,7 +335,7 @@ def pdp_dispense(
         send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
-            "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/PDT-SLOT-1'],
+            "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/PDT-SLOT-1'],
         },
         description=f"move to slot: PDT SLOT 1"
     )
@@ -400,14 +400,14 @@ def pdp_dispense(
             send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
-                "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/DISPOSAL'],
+                "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/DISPOSAL'],
             },
             description=f"move to slot: DISPOSAL"
         )
         i_h = JuniorInstruction(
             send_to_device=Z2_ARM, action_name="put_down",
             action_parameters={
-                "dest_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/DISPOSAL'],
+                "dest_slot": JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/DISPOSAL'],
             },
             description="put down: DISPOSAL"
         )
@@ -416,85 +416,85 @@ def pdp_dispense(
     return ins_list
 
 
-ins_list1 = pick_drop_rack_to(RACK_B, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], BALANCE_SLOT)
+ins_list1 = pick_drop_rack_to(RACK_B, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'], BALANCE_SLOT)
 
 ins_list2 = solid_dispense(sv_vial=SVV_2,
-                           sv_vial_slot=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-2'],
+                           sv_vial_slot=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SVV-SLOT-2'],
                            dest_vials=RSO2Cl_STOCK_SOLUTION_VIALS,
                            amount=10,
                            include_pickup_svtool=True,
                            include_dropoff_svvial=True,
                            include_dropoff_svtool=True)
-ins_list2[0].preceding_instructions.range.add(ins_list1[-1].identifier)
+ins_list2[0].preceding_instructions.add(ins_list1[-1].identifier)
 
-ins_list3 = pick_drop_rack_to(RACK_B, BALANCE_SLOT, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'])
-ins_list3[0].preceding_instructions.range.add(ins_list2[-1].identifier)
+ins_list3 = pick_drop_rack_to(RACK_B, BALANCE_SLOT, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'])
+ins_list3[0].preceding_instructions.add(ins_list2[-1].identifier)
 
-ins_list4 = pick_drop_rack_to(RACK_C, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], BALANCE_SLOT)
-ins_list4[0].preceding_instructions.range.add(ins_list3[-1].identifier)
+ins_list4 = pick_drop_rack_to(RACK_C, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'], BALANCE_SLOT)
+ins_list4[0].preceding_instructions.add(ins_list3[-1].identifier)
 
-ins_list5 = solid_dispense(sv_vial=SVV_1, sv_vial_slot=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-1'],
+ins_list5 = solid_dispense(sv_vial=SVV_1, sv_vial_slot=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SVV-SLOT-1'],
                            dest_vials=MRV_VIALS,
                            amount=10,
                            include_pickup_svtool=True,
                            include_dropoff_svvial=True, include_dropoff_svtool=True)
-ins_list5[0].preceding_instructions.range.add(ins_list4[-1].identifier)
+ins_list5[0].preceding_instructions.add(ins_list4[-1].identifier)
 
-ins_list6 = pick_drop_rack_to(RACK_C, BALANCE_SLOT, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'])
-ins_list6[0].preceding_instructions.range.add(ins_list5[-1].identifier)
+ins_list6 = pick_drop_rack_to(RACK_C, BALANCE_SLOT, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'])
+ins_list6[0].preceding_instructions.add(ins_list5[-1].identifier)
 
-ins_list7 = needle_dispense(DCM_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1'], MRV_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], 10)
-ins_list7[0].preceding_instructions.range.add(ins_list6[-1].identifier)
+ins_list7 = needle_dispense(DCM_VIALS, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-OFF-1'], MRV_VIALS, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'], 10)
+ins_list7[0].preceding_instructions.add(ins_list6[-1].identifier)
 
-ins_list8 = needle_dispense(DCM_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1'], RSO2Cl_STOCK_SOLUTION_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'],
+ins_list8 = needle_dispense(DCM_VIALS, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-OFF-1'], RSO2Cl_STOCK_SOLUTION_VIALS, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'],
                             10)
-ins_list8[0].preceding_instructions.range.add(ins_list7[-1].identifier)
+ins_list8[0].preceding_instructions.add(ins_list7[-1].identifier)
 
-ins_list9 = pdp_dispense(PYRIDINE_VIAL, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], RACK_D_TIPS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'], MRV_VIALS,
-                         JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], 10)
-ins_list9[0].preceding_instructions.range.add(ins_list8[-1].identifier)
+ins_list9 = pdp_dispense(PYRIDINE_VIAL, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'], RACK_D_TIPS, JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-3'], MRV_VIALS,
+                         JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'], 10)
+ins_list9[0].preceding_instructions.add(ins_list8[-1].identifier)
 
 ins_stir1 = JuniorInstruction(
-    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], action_name="wait", action_parameters={"wait_time": 300},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'], action_name="wait", action_parameters={"wait_time": 300},
     description="wait for 5 min"
 )
 ins_stir2 = JuniorInstruction(
-    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], action_name="wait", action_parameters={"wait_time": 300},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'], action_name="wait", action_parameters={"wait_time": 300},
     description="wait for 5 min"
 )
 ins_stir3 = JuniorInstruction(
-    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'], action_name="wait", action_parameters={"wait_time": 300},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-3'], action_name="wait", action_parameters={"wait_time": 300},
     description="wait for 5 min"
 )
 
 for i in [ins_stir1, ins_stir2, ins_stir3]:
-    i.preceding_instructions.range.add(ins_list9[-1].identifier)
+    i.preceding_instructions.add(ins_list9[-1].identifier)
 
 ins_list10 = needle_dispense(
     RSO2Cl_STOCK_SOLUTION_VIALS,
-    JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'],
+    JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'],
     MRV_VIALS,
-    JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'],
+    JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'],
     10
 )
 
-ins_list10[0].preceding_instructions.range = {ins_stir1.identifier, ins_stir2.identifier, ins_stir3.identifier}
+ins_list10[0].preceding_instructions = {ins_stir1.identifier, ins_stir2.identifier, ins_stir3.identifier}
 
 ins_stir21 = JuniorInstruction(
-    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], action_name="wait", action_parameters={"wait_time": 7200},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-1'], action_name="wait", action_parameters={"wait_time": 7200},
     description="wait for 120 min"
 )
 ins_stir22 = JuniorInstruction(
-    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], action_name="wait", action_parameters={"wait_time": 7200},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-2'], action_name="wait", action_parameters={"wait_time": 7200},
     description="wait for 120 min"
 )
 ins_stir23 = JuniorInstruction(
-    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'], action_name="wait", action_parameters={"wait_time": 7200},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.namespace_iri}/SLOT-2-3-3'], action_name="wait", action_parameters={"wait_time": 7200},
     description="wait for 120 min"
 )
 
 for i in [ins_stir21, ins_stir22, ins_stir23]:
-    i.preceding_instructions.range.add(ins_list10[-1].identifier)
+    i.preceding_instructions.add(ins_list10[-1].identifier)
 
 # TODO fix bug `SyntaxError: prefix 'down' not found in prefix map`
 # diagram = JUNIOR_LAB.instruction_graph

--- a/sim_junior/sim_junior.py
+++ b/sim_junior/sim_junior.py
@@ -11,77 +11,77 @@ CONCURRENCY = 1
 
 # RACK A: holding HRVs with DCM, on off deck initially
 RACK_A, RACK_A_VIALS = JuniorRack.create_rack_with_empty_vials(
-    n_vials=CONCURRENCY, rack_capacity=6, vial_type="HRV", rack_id="RACK A"
+    n_vials=CONCURRENCY, rack_capacity=6, vial_type="HRV", rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-A"
 )
 RACK_A: JuniorRack
 RACK_A_VIALS: list[JuniorVial]
 for v in RACK_A_VIALS:
-    v.chemical_content = {"DCM": 1000}
-JuniorSlot.put_rack_in_a_slot(RACK_A, JUNIOR_LAB['SLOT OFF-1'])
+    v.add_content({"DCM": 1000})
+JuniorSlot.put_rack_in_a_slot(RACK_A, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1'])
 
 # RACK B: holding HRVs for reactions, at 2-3-2 initially, one for RSO2Cl stock solution, another for pyridine source
 RACK_B, RACK_B_VIALS = JuniorRack.create_rack_with_empty_vials(
-    n_vials=CONCURRENCY + 1, rack_capacity=8, vial_type="HRV", rack_id="RACK B"
+    n_vials=CONCURRENCY + 1, rack_capacity=8, vial_type="HRV", rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-B"
 )
 RACK_B: JuniorRack
 RACK_B_VIALS: list[JuniorVial]
-JuniorSlot.put_rack_in_a_slot(RACK_B, JUNIOR_LAB['SLOT 2-3-2'])
+JuniorSlot.put_rack_in_a_slot(RACK_B, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'])
 
 # RACK C: holding one MRV for reaction, at 2-3-1 initially
 RACK_C, RACK_C_VIALS = JuniorRack.create_rack_with_empty_vials(
-    n_vials=CONCURRENCY, rack_capacity=6, vial_type="MRV", rack_id="RACK C"
+    n_vials=CONCURRENCY, rack_capacity=6, vial_type="MRV", rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-C"
 )
 RACK_C: JuniorRack
 RACK_C_VIALS: list[JuniorVial]
-JuniorSlot.put_rack_in_a_slot(RACK_C, JUNIOR_LAB['SLOT 2-3-1'])
+JuniorSlot.put_rack_in_a_slot(RACK_C, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'])
 
 # RACK D: holding PDP tips, at 2-3-3 initially
 RACK_D, RACK_D_TIPS = JuniorRack.create_rack_with_empty_tips(
-    n_tips=CONCURRENCY, rack_capacity=6, rack_id="RACK D", tip_id_inherit=True
+    n_tips=CONCURRENCY, rack_capacity=6, rack_id=f"{JuniorOntology.get_namespace_iri()}/RACK-D", tip_id_inherit=True
 )
 RACK_D: JuniorRack
 RACK_D_TIPS: list[JuniorPdpTip]
-JuniorSlot.put_rack_in_a_slot(RACK_D, JUNIOR_LAB['SLOT 2-3-3'])
+JuniorSlot.put_rack_in_a_slot(RACK_D, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'])
 
 # SV VIALS, one for solid amine (aniline), another for RSO2Cl, each sits in a SVV SLOT
 SVV_1 = JuniorVial(
-    identifier="SV VIAL 1", contained_by=JUNIOR_LAB['SVV SLOT 1'].identifier,
-    chemical_content={'solid amine': 1000},
-    vial_type='SV',
+    identifier=f"{JuniorOntology.get_namespace_iri()}/SV-VIAL-1", contained_by=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-1'].identifier,
+    vial_type='SV', contained_in_slot='SLOT'
 )
+SVV_1.add_content({"solid amine": 1000})
 SVV_2 = JuniorVial(
-    identifier="SV VIAL 2", contained_by=JUNIOR_LAB['SVV SLOT 2'].identifier,
-    chemical_content={'sulfonyl chloride': 1000},
-    vial_type='SV',
+    identifier=f"{JuniorOntology.get_namespace_iri()}/SV-VIAL-2", contained_by=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-2'].identifier,
+    vial_type='SV', contained_in_slot='SLOT'
 )
-JUNIOR_LAB['SVV SLOT 1'].slot_content['SLOT'] = SVV_1.identifier
-JUNIOR_LAB['SVV SLOT 2'].slot_content['SLOT'] = SVV_2.identifier
+SVV_2.add_content({'sulfonyl chloride': 1000})
+JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-1'].has_slot_content.range.add(SVV_1)
+JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-2'].has_slot_content.range.add(SVV_2)
 
 # INSTRUCTIONS
-Z1_ARM = JUNIOR_LAB['Z1 ARM']
-Z2_ARM = JUNIOR_LAB['Z2 ARM']
-ARM_PLATFORM = JUNIOR_LAB['ARM PLATFORM']
+Z1_ARM = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/Z1-ARM']
+Z2_ARM = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/Z2-ARM']
+ARM_PLATFORM = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/ARM-PLATFORM']
 
-Z1NEEDLES = [JUNIOR_LAB[f"Z1 Needle {i + 1}"] for i in range(CONCURRENCY)]
+Z1NEEDLES = [JUNIOR_LAB[f"{JuniorOntology.get_namespace_iri()}/Z1-Needle-{i + 1}"] for i in range(CONCURRENCY)]
 
-VPG = JUNIOR_LAB['VPG']
-VPG_SLOT = JUNIOR_LAB['VPG SLOT']
-SV_TOOL = JUNIOR_LAB['SV TOOL']
-SV_TOOL_SLOT = JUNIOR_LAB['SV TOOL SLOT']
-BALANCE_SLOT = JUNIOR_LAB['BALANCE SLOT']
+VPG = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/VPG']
+VPG_SLOT = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/VPG-SLOT']
+SV_TOOL = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SV-TOOL']
+SV_TOOL_SLOT = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SV-TOOL-SLOT']
+BALANCE_SLOT = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/BALANCE-SLOT']
 
-PDP_1 = JUNIOR_LAB['PDT 1']
+PDP_1 = JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/PDT-1']
 
 DCM_VIALS = RACK_A_VIALS
 MRV_VIALS = RACK_C_VIALS
 PYRIDINE_VIAL = RACK_B_VIALS[0]
 RSO2Cl_STOCK_SOLUTION_VIALS = RACK_B_VIALS[1:]
-PYRIDINE_VIAL.chemical_content = {"pyridine": 1000}
+PYRIDINE_VIAL.add_content({"pyridine": 1000})
 
 
 def pick_drop_rack_to(rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorSlot):
     ins1 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
             "move_to_slot": VPG_SLOT,
@@ -90,7 +90,7 @@ def pick_drop_rack_to(rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorS
     )
 
     ins2 = JuniorInstruction(
-        device=Z2_ARM, action_name="pick_up",
+        send_to_device=Z2_ARM, action_name="pick_up",
         action_parameters={
             "thing": VPG,
         },
@@ -98,7 +98,7 @@ def pick_drop_rack_to(rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorS
     )
 
     ins3 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
             "move_to_slot": src_slot,
@@ -106,14 +106,14 @@ def pick_drop_rack_to(rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorS
         description=f"move to slot: {src_slot.identifier}"
     )
     ins4 = JuniorInstruction(
-        device=Z2_ARM, action_name="pick_up",
+        send_to_device=Z2_ARM, action_name="pick_up",
         action_parameters={
             "thing": rack,
         },
         description=f"pick up: {rack.identifier}"
     )
     ins5 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
             "move_to_slot": dest_slot,
@@ -121,7 +121,7 @@ def pick_drop_rack_to(rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorS
         description=f"move to slot: {dest_slot.identifier}"
     )
     ins6 = JuniorInstruction(
-        device=Z2_ARM, action_name="put_down",
+        send_to_device=Z2_ARM, action_name="put_down",
         action_parameters={
             "dest_slot": dest_slot,
         },
@@ -129,7 +129,7 @@ def pick_drop_rack_to(rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorS
     )
 
     ins7 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
             "move_to_slot": VPG_SLOT,
@@ -138,7 +138,7 @@ def pick_drop_rack_to(rack: JuniorRack, src_slot: JuniorSlot, dest_slot: JuniorS
     )
 
     ins8 = JuniorInstruction(
-        device=Z2_ARM, action_name="put_down",
+        send_to_device=Z2_ARM, action_name="put_down",
         action_parameters={
             "dest_slot": VPG_SLOT,
         },
@@ -161,7 +161,7 @@ def solid_dispense(
         include_dropoff_svtool=True,
 ):
     ins3 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
             "move_to_slot": sv_vial_slot,
@@ -170,13 +170,13 @@ def solid_dispense(
     )
 
     ins4 = JuniorInstruction(
-        device=Z2_ARM, action_name="pick_up",
+        send_to_device=Z2_ARM, action_name="pick_up",
         action_parameters={"thing": sv_vial},
         description=f"pick up: {sv_vial.identifier}",
     )
 
     ins5 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
             "move_to_slot": BALANCE_SLOT,
@@ -186,7 +186,7 @@ def solid_dispense(
 
     if include_pickup_svtool:
         ins1 = JuniorInstruction(
-            device=ARM_PLATFORM, action_name="move_to",
+            send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
                 "move_to_slot": SV_TOOL_SLOT,
@@ -195,7 +195,7 @@ def solid_dispense(
         )
 
         ins2 = JuniorInstruction(
-            device=Z2_ARM, action_name="pick_up",
+            send_to_device=Z2_ARM, action_name="pick_up",
             action_parameters={"thing": SV_TOOL},
             description=f"pick up: {SV_TOOL.identifier}",
         )
@@ -205,7 +205,7 @@ def solid_dispense(
 
     for dest_vial in dest_vials:
         ins6 = JuniorInstruction(
-            device=Z2_ARM, action_name="dispense_sv",
+            send_to_device=Z2_ARM, action_name="dispense_sv",
             action_parameters={
                 "destination_container": dest_vial,
                 "amount": amount,
@@ -217,7 +217,7 @@ def solid_dispense(
 
     if include_dropoff_svvial:
         ins7 = JuniorInstruction(
-            device=ARM_PLATFORM, action_name="move_to",
+            send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
                 "move_to_slot": sv_vial_slot,
@@ -226,7 +226,7 @@ def solid_dispense(
         )
 
         ins8 = JuniorInstruction(
-            device=Z2_ARM, action_name="put_down",
+            send_to_device=Z2_ARM, action_name="put_down",
             action_parameters={
                 "dest_slot": sv_vial_slot,
             },
@@ -237,7 +237,7 @@ def solid_dispense(
 
     if include_dropoff_svtool:
         ins9 = JuniorInstruction(
-            device=ARM_PLATFORM, action_name="move_to",
+            send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
                 "move_to_slot": SV_TOOL_SLOT,
@@ -246,7 +246,7 @@ def solid_dispense(
         )
 
         ins10 = JuniorInstruction(
-            device=Z2_ARM, action_name="put_down",
+            send_to_device=Z2_ARM, action_name="put_down",
             action_parameters={
                 "dest_slot": SV_TOOL_SLOT,
             },
@@ -269,7 +269,7 @@ def needle_dispense(
         # speed: float,
 ):
     ins1 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z1_ARM,
             "move_to_slot": src_slot,
@@ -277,7 +277,7 @@ def needle_dispense(
         description=f"move to slot: {src_slot.identifier}"
     )
     ins2 = JuniorInstruction(
-        device=Z1_ARM, action_name="concurrent_aspirate",
+        send_to_device=Z1_ARM, action_name="concurrent_aspirate",
         action_parameters={
             "source_containers": src_vials,
             "dispenser_containers": Z1NEEDLES,
@@ -287,7 +287,7 @@ def needle_dispense(
         description=f"concurrent aspirate from: {','.join([v.identifier for v in src_vials])}"
     )
     ins3 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z1_ARM,
             "move_to_slot": dest_vials_slot,
@@ -295,7 +295,7 @@ def needle_dispense(
         description=f"move to slot: {dest_vials_slot.identifier}"
     )
     ins4 = JuniorInstruction(
-        device=Z1_ARM, action_name="concurrent_dispense",
+        send_to_device=Z1_ARM, action_name="concurrent_dispense",
         action_parameters={
             "destination_containers": dest_vials,
             "dispenser_containers": Z1NEEDLES,
@@ -305,17 +305,17 @@ def needle_dispense(
         description=f"concurrent dispense to: {','.join([v.identifier for v in dest_vials])}"
     )
     ins5 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z1_ARM,
-            "move_to_slot": JUNIOR_LAB['WASH BAY'],
+            "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/WASH-BAY'],
         },
         description=f"move to slot: WASH BAY"
     )
     ins6 = JuniorInstruction(
-        device=Z1_ARM, action_name="wash",
+        send_to_device=Z1_ARM, action_name="wash",
         action_parameters={
-            "wash_bay": JUNIOR_LAB['WASH BAY'],
+            "wash_bay": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/WASH-BAY'],
         },
         description="wash needles"
     )
@@ -332,16 +332,16 @@ def pdp_dispense(
         # speed: float
 ):
     ins1 = JuniorInstruction(
-        device=ARM_PLATFORM, action_name="move_to",
+        send_to_device=ARM_PLATFORM, action_name="move_to",
         action_parameters={
             "anchor_arm": Z2_ARM,
-            "move_to_slot": JUNIOR_LAB['PDT SLOT 1'],
+            "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/PDT-SLOT-1'],
         },
         description=f"move to slot: PDT SLOT 1"
     )
 
     ins2 = JuniorInstruction(
-        device=Z2_ARM, action_name="pick_up",
+        send_to_device=Z2_ARM, action_name="pick_up",
         action_parameters={"thing": PDP_1},
         description=f"pick up: {PDP_1.identifier}",
     )
@@ -350,7 +350,7 @@ def pdp_dispense(
 
     for tip, dest_vial in zip(tips, dest_vials):
         i_a = JuniorInstruction(
-            device=ARM_PLATFORM, action_name="move_to",
+            send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
                 "move_to_slot": tips_slot,
@@ -358,12 +358,12 @@ def pdp_dispense(
             description=f"move to slot: {tips_slot.identifier}"
         )
         i_b = JuniorInstruction(
-            device=Z2_ARM, action_name="pick_up",
+            send_to_device=Z2_ARM, action_name="pick_up",
             action_parameters={"thing": tip},
             description=f"pick up: {tip.identifier}",
         )
         i_c = JuniorInstruction(
-            device=ARM_PLATFORM, action_name="move_to",
+            send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
                 "move_to_slot": src_slot,
@@ -371,7 +371,7 @@ def pdp_dispense(
             description=f"move to slot: {src_slot.identifier}"
         )
         i_d = JuniorInstruction(
-            device=Z2_ARM, action_name="aspirate_pdp",
+            send_to_device=Z2_ARM, action_name="aspirate_pdp",
             action_parameters={
                 "source_container": src_vial,
                 "amount": amount,
@@ -380,7 +380,7 @@ def pdp_dispense(
             description=f"aspirate_pdp from: {src_vial.identifier}"
         )
         i_e = JuniorInstruction(
-            device=ARM_PLATFORM, action_name="move_to",
+            send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
                 "move_to_slot": dest_vials_slot,
@@ -388,7 +388,7 @@ def pdp_dispense(
             description=f"move to slot: {dest_vials_slot.identifier}"
         )
         i_f = JuniorInstruction(
-            device=Z2_ARM, action_name="dispense_pdp",
+            send_to_device=Z2_ARM, action_name="dispense_pdp",
             action_parameters={
                 "destination_container": dest_vial,
                 "amount": amount,
@@ -397,17 +397,17 @@ def pdp_dispense(
             description=f"dispense_pdp to: {dest_vial.identifier}"
         )
         i_g = JuniorInstruction(
-            device=ARM_PLATFORM, action_name="move_to",
+            send_to_device=ARM_PLATFORM, action_name="move_to",
             action_parameters={
                 "anchor_arm": Z2_ARM,
-                "move_to_slot": JUNIOR_LAB['DISPOSAL'],
+                "move_to_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/DISPOSAL'],
             },
             description=f"move to slot: DISPOSAL"
         )
         i_h = JuniorInstruction(
-            device=Z2_ARM, action_name="put_down",
+            send_to_device=Z2_ARM, action_name="put_down",
             action_parameters={
-                "dest_slot": JUNIOR_LAB['DISPOSAL'],
+                "dest_slot": JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/DISPOSAL'],
             },
             description="put down: DISPOSAL"
         )
@@ -416,84 +416,91 @@ def pdp_dispense(
     return ins_list
 
 
-ins_list1 = pick_drop_rack_to(RACK_B, JUNIOR_LAB['SLOT 2-3-2'], BALANCE_SLOT)
+ins_list1 = pick_drop_rack_to(RACK_B, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], BALANCE_SLOT)
 
 ins_list2 = solid_dispense(sv_vial=SVV_2,
-                           sv_vial_slot=JUNIOR_LAB['SVV SLOT 2'],
+                           sv_vial_slot=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-2'],
                            dest_vials=RSO2Cl_STOCK_SOLUTION_VIALS,
                            amount=10,
                            include_pickup_svtool=True,
                            include_dropoff_svvial=True,
                            include_dropoff_svtool=True)
-ins_list2[0].preceding_instructions.append(ins_list1[-1].identifier)
+ins_list2[0].preceding_instructions.range.add(ins_list1[-1].identifier)
 
-ins_list3 = pick_drop_rack_to(RACK_B, BALANCE_SLOT, JUNIOR_LAB['SLOT 2-3-2'])
-ins_list3[0].preceding_instructions.append(ins_list2[-1].identifier)
+ins_list3 = pick_drop_rack_to(RACK_B, BALANCE_SLOT, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'])
+ins_list3[0].preceding_instructions.range.add(ins_list2[-1].identifier)
 
-ins_list4 = pick_drop_rack_to(RACK_C, JUNIOR_LAB['SLOT 2-3-1'], BALANCE_SLOT)
-ins_list4[0].preceding_instructions.append(ins_list3[-1].identifier)
+ins_list4 = pick_drop_rack_to(RACK_C, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], BALANCE_SLOT)
+ins_list4[0].preceding_instructions.range.add(ins_list3[-1].identifier)
 
-ins_list5 = solid_dispense(sv_vial=SVV_1, sv_vial_slot=JUNIOR_LAB['SVV SLOT 1'],
+ins_list5 = solid_dispense(sv_vial=SVV_1, sv_vial_slot=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SVV-SLOT-1'],
                            dest_vials=MRV_VIALS,
                            amount=10,
                            include_pickup_svtool=True,
                            include_dropoff_svvial=True, include_dropoff_svtool=True)
-ins_list5[0].preceding_instructions.append(ins_list4[-1].identifier)
+ins_list5[0].preceding_instructions.range.add(ins_list4[-1].identifier)
 
-ins_list6 = pick_drop_rack_to(RACK_C, BALANCE_SLOT, JUNIOR_LAB['SLOT 2-3-1'])
-ins_list6[0].preceding_instructions.append(ins_list5[-1].identifier)
+ins_list6 = pick_drop_rack_to(RACK_C, BALANCE_SLOT, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'])
+ins_list6[0].preceding_instructions.range.add(ins_list5[-1].identifier)
 
-ins_list7 = needle_dispense(DCM_VIALS, JUNIOR_LAB['SLOT OFF-1'], MRV_VIALS, JUNIOR_LAB['SLOT 2-3-1'], 10)
-ins_list7[0].preceding_instructions.append(ins_list6[-1].identifier)
+ins_list7 = needle_dispense(DCM_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1'], MRV_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], 10)
+ins_list7[0].preceding_instructions.range.add(ins_list6[-1].identifier)
 
-ins_list8 = needle_dispense(DCM_VIALS, JUNIOR_LAB['SLOT OFF-1'], RSO2Cl_STOCK_SOLUTION_VIALS, JUNIOR_LAB['SLOT 2-3-2'],
+ins_list8 = needle_dispense(DCM_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-OFF-1'], RSO2Cl_STOCK_SOLUTION_VIALS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'],
                             10)
-ins_list8[0].preceding_instructions.append(ins_list7[-1].identifier)
+ins_list8[0].preceding_instructions.range.add(ins_list7[-1].identifier)
 
-ins_list9 = pdp_dispense(PYRIDINE_VIAL, JUNIOR_LAB['SLOT 2-3-2'], RACK_D_TIPS, JUNIOR_LAB['SLOT 2-3-3'], MRV_VIALS,
-                         JUNIOR_LAB['SLOT 2-3-1'], 10)
-ins_list9[0].preceding_instructions.append(ins_list8[-1].identifier)
+ins_list9 = pdp_dispense(PYRIDINE_VIAL, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], RACK_D_TIPS, JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'], MRV_VIALS,
+                         JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], 10)
+ins_list9[0].preceding_instructions.range.add(ins_list8[-1].identifier)
 
 ins_stir1 = JuniorInstruction(
-    device=JUNIOR_LAB['SLOT 2-3-1'], action_name="wait", action_parameters={"wait_time": 300},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], action_name="wait", action_parameters={"wait_time": 300},
     description="wait for 5 min"
 )
 ins_stir2 = JuniorInstruction(
-    device=JUNIOR_LAB['SLOT 2-3-2'], action_name="wait", action_parameters={"wait_time": 300},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], action_name="wait", action_parameters={"wait_time": 300},
     description="wait for 5 min"
 )
 ins_stir3 = JuniorInstruction(
-    device=JUNIOR_LAB['SLOT 2-3-3'], action_name="wait", action_parameters={"wait_time": 300},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'], action_name="wait", action_parameters={"wait_time": 300},
     description="wait for 5 min"
 )
 
 for i in [ins_stir1, ins_stir2, ins_stir3]:
-    i.preceding_instructions.append(ins_list9[-1].identifier)
+    i.preceding_instructions.range.add(ins_list9[-1].identifier)
 
-ins_list10 = needle_dispense(RSO2Cl_STOCK_SOLUTION_VIALS, JUNIOR_LAB['SLOT 2-3-2'], MRV_VIALS, JUNIOR_LAB['SLOT 2-3-1'],
-                             10)
-ins_list10[0].preceding_instructions = [ins_stir1.identifier, ins_stir2.identifier, ins_stir3.identifier]
+ins_list10 = needle_dispense(
+    RSO2Cl_STOCK_SOLUTION_VIALS,
+    JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'],
+    MRV_VIALS,
+    JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'],
+    10
+)
+
+ins_list10[0].preceding_instructions.range = {ins_stir1.identifier, ins_stir2.identifier, ins_stir3.identifier}
 
 ins_stir21 = JuniorInstruction(
-    device=JUNIOR_LAB['SLOT 2-3-1'], action_name="wait", action_parameters={"wait_time": 7200},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-1'], action_name="wait", action_parameters={"wait_time": 7200},
     description="wait for 120 min"
 )
 ins_stir22 = JuniorInstruction(
-    device=JUNIOR_LAB['SLOT 2-3-2'], action_name="wait", action_parameters={"wait_time": 7200},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-2'], action_name="wait", action_parameters={"wait_time": 7200},
     description="wait for 120 min"
 )
 ins_stir23 = JuniorInstruction(
-    device=JUNIOR_LAB['SLOT 2-3-3'], action_name="wait", action_parameters={"wait_time": 7200},
+    send_to_device=JUNIOR_LAB[f'{JuniorOntology.get_namespace_iri()}/SLOT-2-3-3'], action_name="wait", action_parameters={"wait_time": 7200},
     description="wait for 120 min"
 )
 
 for i in [ins_stir21, ins_stir22, ins_stir23]:
-    i.preceding_instructions.append(ins_list10[-1].identifier)
+    i.preceding_instructions.range.add(ins_list10[-1].identifier)
 
-diagram = JUNIOR_LAB.instruction_graph
+# TODO fix bug `SyntaxError: prefix 'down' not found in prefix map`
+# diagram = JUNIOR_LAB.instruction_graph
 
-diagram.layout(algo="rt_circular")
-diagram.dump_file(filename="sim_junior_instruction.drawio", folder="./")
+# diagram.layout(algo="rt_circular")
+# diagram.dump_file(filename="sim_junior_instruction.drawio", folder="./")
 
 from casymda_hardware.model import *
 import simpy
@@ -506,9 +513,11 @@ env.run()
 
 JuniorOntology.export_to_owl("junior_lab_tbox.ttl")
 print("TBox exported to junior_lab_tbox.ttl")
-from rdflib import Graph
-g2r = Graph()
-g2a = Graph()
-g2r, g2a = JUNIOR_LAB.collect_diff_to_graph(g2r, g2a, -1)
-g2a.serialize(destination="junior_lab_abox.ttl", format="turtle")
+
+g = KnowledgeGraph.graph()
+g.serialize(destination="junior_lab_abox.ttl", format="turtle")
+# from twa.kg_operations import PySparqlClient
+# endpoint = 'http://localhost:9999/blazegraph/namespace/kb/sparql'
+# sparql_client = PySparqlClient(endpoint, endpoint)
+# sparql_client.upload_graph(g)
 print("ABox exported to junior_lab_abox.ttl")

--- a/sim_junior/sulfonylation/parallel.py
+++ b/sim_junior/sulfonylation/parallel.py
@@ -90,16 +90,16 @@ def get_ins_lst_dcm_dispense():
 def get_ins_lst_reaction():
     """ capping, stir and let the reactions proceed """
     ins_cap = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 30 * len(SULFONYL_BENCHTOP.REACTOR_VIALS)},
         description="capping reactors"
     )
     ins_stir = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 300},
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 300},
         description="wait for 5 min"
     )
     ins_reaction = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 60 * 120},
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 60 * 120},
         description="wait for 120 min"
     )
     lst = [ins_cap, ins_stir, ins_reaction]

--- a/sim_junior/sulfonylation/parallel.py
+++ b/sim_junior/sulfonylation/parallel.py
@@ -141,10 +141,9 @@ def simulate(name):
     # diagram.layout(algo="rt_circular")
     # diagram.dump_file(filename=f"{name}.drawio", folder="./")
 
-    # TODO fix this
-    # # dump as json
-    # with open(f"{name}.json", "w") as f:
-    #     json.dump([v.as_dict(identifier_only=True) for v in JUNIOR_LAB.dict_instruction.values()], f, indent=2)
+    # dump as json
+    with open(f"{name}.json", "w") as f:
+        json.dump([v.as_dict(identifier_only=True) for v in JUNIOR_LAB.dict_instruction.values()], f, indent=2)
 
     env = simpy.Environment()
     Model(env, JUNIOR_LAB, wdir=os.path.abspath("./"), model_name=name)

--- a/sim_junior/sulfonylation/parallel.py
+++ b/sim_junior/sulfonylation/parallel.py
@@ -135,14 +135,16 @@ def define_instructions():
 def simulate(name):
     define_instructions()
 
-    # dump as `drawio` editable
-    diagram = JUNIOR_LAB.instruction_graph
-    diagram.layout(algo="rt_circular")
-    diagram.dump_file(filename=f"{name}.drawio", folder="./")
+    # TODO fix this
+    # # dump as `drawio` editable
+    # diagram = JUNIOR_LAB.instruction_graph
+    # diagram.layout(algo="rt_circular")
+    # diagram.dump_file(filename=f"{name}.drawio", folder="./")
 
-    # dump as json
-    with open(f"{name}.json", "w") as f:
-        json.dump([v.as_dict(identifier_only=True) for v in JUNIOR_LAB.dict_instruction.values()], f, indent=2)
+    # TODO fix this
+    # # dump as json
+    # with open(f"{name}.json", "w") as f:
+    #     json.dump([v.as_dict(identifier_only=True) for v in JUNIOR_LAB.dict_instruction.values()], f, indent=2)
 
     env = simpy.Environment()
     Model(env, JUNIOR_LAB, wdir=os.path.abspath("./"), model_name=name)
@@ -153,3 +155,7 @@ if __name__ == '__main__':
     import os.path
 
     simulate(os.path.basename(__file__).rstrip(".py"))
+    g = KnowledgeGraph.graph()
+    g.serialize(destination="parallel.ttl", format="turtle")
+    print("ABox exported to parallel.ttl")
+

--- a/sim_junior/tips_pn/grignard.py
+++ b/sim_junior/tips_pn/grignard.py
@@ -76,12 +76,12 @@ def get_ins_lst_abcd():
 
     # d
     ins_cap = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 30 * len(REACTION_BENCHTOP.REACTOR_VIALS)},
         description="capping reactors"
     )
     ins_heat = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 15 * 60},
         description="60 C wait for 15 min"
     )
@@ -99,12 +99,12 @@ def get_ins_lst_ghi():
 
     # h
     ins_cap = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 30 * len(REACTION_BENCHTOP.REACTOR_VIALS)},
         description="capping reactors"
     )
     ins_heat = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 15 * 60},
         description="60 C wait for 30 min"
     )

--- a/sim_junior/tips_pn/grignard.py
+++ b/sim_junior/tips_pn/grignard.py
@@ -130,9 +130,10 @@ def define_instructions():
 def simulate(name):
     define_instructions()
 
-    diagram = JUNIOR_LAB.instruction_graph
-    diagram.layout(algo="rt_circular")
-    diagram.dump_file(filename=f"{name}.drawio", folder="./")
+    # TODO fix this
+    # diagram = JUNIOR_LAB.instruction_graph
+    # diagram.layout(algo="rt_circular")
+    # diagram.dump_file(filename=f"{name}.drawio", folder="./")
     env = simpy.Environment()
     Model(env, JUNIOR_LAB, wdir=os.path.abspath("./"), model_name=name)
     env.run()
@@ -142,3 +143,6 @@ if __name__ == '__main__':
     import os.path
 
     simulate(os.path.basename(__file__).rstrip(".py"))
+    g = KnowledgeGraph.graph()
+    g.serialize(destination="grignard.ttl", format="turtle")
+    print("ABox exported to grignard.ttl")

--- a/sim_junior/tips_pn/quinone.py
+++ b/sim_junior/tips_pn/quinone.py
@@ -85,12 +85,12 @@ def get_ins_lst_liquid_dispense():
 @ins_list_path_graph
 def get_ins_lst_reaction():
     ins_cap = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 30 * len(REACTION_BENCHTOP.REACTOR_VIALS)},
         description="capping reactors"
     )
     ins_reaction = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 60 * 240},
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 60 * 240},
         description="wait for 240 min"
     )
     lst = [ins_cap, ins_reaction]
@@ -106,7 +106,7 @@ def define_instructions():
                                                  JUNIOR_BENCHTOP.SLOT_2_3_3, REACTION_BENCHTOP.REACTOR_VIALS,
                                                  JUNIOR_BENCHTOP.SLOT_2_3_1, 0.04)
     ins_lst_stir = [JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 300},
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 300},
         description="wait for 5 min"
     ), ]
     # TODO there is a redundant `move_to` action to pick up pdp, even tho pdp is already on z2

--- a/sim_junior/tips_pn/quinone.py
+++ b/sim_junior/tips_pn/quinone.py
@@ -132,9 +132,10 @@ def define_instructions():
 def simulate(name):
     define_instructions()
 
-    diagram = JUNIOR_LAB.instruction_graph
-    diagram.layout(algo="rt_circular")
-    diagram.dump_file(filename=f"{name}.drawio", folder="./")
+    # TODO fix this
+    # diagram = JUNIOR_LAB.instruction_graph
+    # diagram.layout(algo="rt_circular")
+    # diagram.dump_file(filename=f"{name}.drawio", folder="./")
     env = simpy.Environment()
     Model(env, JUNIOR_LAB, wdir=os.path.abspath("./"), model_name=name)
     env.run()
@@ -144,3 +145,6 @@ if __name__ == '__main__':
     import os.path
 
     simulate(os.path.basename(__file__).rstrip(".py"))
+    g = KnowledgeGraph.graph()
+    g.serialize(destination="quinone.ttl", format="turtle")
+    print("ABox exported to quinone.ttl")

--- a/sim_junior/tips_pn/tandem.py
+++ b/sim_junior/tips_pn/tandem.py
@@ -291,9 +291,10 @@ def define_instructions():
 def simulate(name):
     define_instructions()
 
-    diagram = JUNIOR_LAB.instruction_graph
-    diagram.layout(algo="rt_circular")
-    diagram.dump_file(filename=f"{name}.drawio", folder="./")
+    # TODO fix this
+    # diagram = JUNIOR_LAB.instruction_graph
+    # diagram.layout(algo="rt_circular")
+    # diagram.dump_file(filename=f"{name}.drawio", folder="./")
     env = simpy.Environment()
     Model(env, JUNIOR_LAB, wdir=os.path.abspath("./"), model_name=name)
     env.run()
@@ -303,3 +304,7 @@ if __name__ == '__main__':
     import os.path
 
     simulate(os.path.basename(__file__).rstrip(".py"))
+    g = KnowledgeGraph.graph()
+    g.serialize(destination="tandem.ttl", format="turtle")
+    print("ABox exported to tandem.ttl")
+

--- a/sim_junior/tips_pn/tandem.py
+++ b/sim_junior/tips_pn/tandem.py
@@ -94,12 +94,12 @@ def get_ins_lst_liquid_dispense():
 @ins_list_path_graph
 def get_ins_lst_reaction():
     ins_cap = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 30 * len(REACTION_BENCHTOP.quinone_benchtop.REACTOR_VIALS)},
         description="capping reactors"
     )
     ins_reaction = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 60 * 240},
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 60 * 240},
         description="wait for 240 min"
     )
     lst = [ins_cap, ins_reaction]
@@ -164,12 +164,12 @@ def get_ins_lst_abcd():
 
     # d
     ins_cap = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 30 * len(REACTION_BENCHTOP.grignard_benchtop.REACTOR_VIALS)},
         description="capping reactors"
     )
     ins_heat = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 15 * 60},
         description="60 C wait for 15 min"
     )
@@ -189,12 +189,12 @@ def get_ins_lst_ghi():
 
     # h
     ins_cap = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 30 * len(REACTION_BENCHTOP.grignard_benchtop.REACTOR_VIALS)},
         description="capping reactors"
     )
     ins_heat = JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait",
         action_parameters={"wait_time": 15 * 60},
         description="60 C wait for 30 min"
     )
@@ -216,7 +216,7 @@ def get_ins_lst_magic():
     lst = []
     for v in REACTION_BENCHTOP.quinone_benchtop.REACTOR_VIALS:
         ins = JuniorInstruction(
-            device=REACTION_BENCHTOP.mage,
+            send_to_device=REACTION_BENCHTOP.mage,
             action_name="set_vial_chemical_content",
             action_parameters={
                 "vial": v,
@@ -228,7 +228,7 @@ def get_ins_lst_magic():
         lst.append(ins)
     v = REACTION_BENCHTOP.grignard_benchtop.QUINONE_SVV
     ins = JuniorInstruction(
-        device=REACTION_BENCHTOP.mage,
+        send_to_device=REACTION_BENCHTOP.mage,
         action_name="set_vial_chemical_content",
         action_parameters={
             "vial": v,
@@ -252,7 +252,7 @@ def define_instructions():
                                                  REACTION_BENCHTOP.quinone_benchtop.REACTOR_VIALS,
                                                  JUNIOR_BENCHTOP.SLOT_2_3_1, 0.04)
     ins_lst_stir = [JuniorInstruction(
-        device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 300},
+        send_to_device=JUNIOR_BENCHTOP.SLOT_2_3_1, action_name="wait", action_parameters={"wait_time": 300},
         description="wait for 5 min"
     ), ]
     # TODO there is a redundant `move_to` action to pick up pdp, even tho pdp is already on z2

--- a/sim_junior/vis_junior.py
+++ b/sim_junior/vis_junior.py
@@ -83,10 +83,10 @@ def get_layout_figure(lab: Lab) -> go.Figure:
 
     for k, v in lab.dict_object.items():
         if isinstance(v, (JuniorSlot, JuniorWashBay, JuniorTipDisposal)):
-            layout = v.layout.get_range_assume_one()
+            layout = list(v.layout)[0]
             layout: JuniorLayout
-            layout_x = layout.layout_x.get_range_assume_one()
-            layout_y = layout.layout_y.get_range_assume_one()
+            layout_x = list(layout.layout_x)[0]
+            layout_y = list(layout.layout_y)[0]
             x0, y0 = layout.layout_position
             x1 = x0 + layout_x
             y1 = y0 + layout_y

--- a/sim_junior/vis_junior.py
+++ b/sim_junior/vis_junior.py
@@ -83,9 +83,13 @@ def get_layout_figure(lab: Lab) -> go.Figure:
 
     for k, v in lab.dict_object.items():
         if isinstance(v, (JuniorSlot, JuniorWashBay, JuniorTipDisposal)):
-            x0, y0 = v.layout.layout_position
-            x1 = x0 + v.layout.layout_x
-            y1 = y0 + v.layout.layout_y
+            layout = v.layout.get_range_assume_one()
+            layout: JuniorLayout
+            layout_x = layout.layout_x.get_range_assume_one()
+            layout_y = layout.layout_y.get_range_assume_one()
+            x0, y0 = layout.layout_position
+            x1 = x0 + layout_x
+            y1 = y0 + layout_y
 
             if isinstance(v, JuniorSlot) and v.slot_content['SLOT'] is not None:
                 fillcolor = "gray"
@@ -100,8 +104,8 @@ def get_layout_figure(lab: Lab) -> go.Figure:
             )
             fig.add_trace(
                 go.Scatter(
-                    x=[x0, x0, x0 + v.layout.layout_x, x0 + v.layout.layout_x],
-                    y=[y0, y0 + v.layout.layout_y, y0 + v.layout.layout_y, y0],
+                    x=[x0, x0, x0 + layout_x, x0 + layout_x],
+                    y=[y0, y0 + layout_y, y0 + layout_y, y0],
                     fill="toself",
                     mode='lines',
                     name='',
@@ -117,7 +121,7 @@ def get_layout_figure(lab: Lab) -> go.Figure:
             else:
                 bgcolor = None
 
-            fig.add_annotation(x=x0 + v.layout.layout_x / 2, y=y0 + v.layout.layout_y / 2,
+            fig.add_annotation(x=x0 + layout_x / 2, y=y0 + layout_y / 2,
                                font={"color": "black"},
                                text=v.identifier,
                                bordercolor=bgcolor,


### PR DESCRIPTION
This PR refactors the class to instantiate from `twa.data_model.base_ontology.BaseClass` and adds relevant object/data properties. The resulting triples from the simulation can be exported by calling functions offered by `twa`.

The version used for development: `twa>0.0.4a0`

Tested working simulations:
- `sim_junior/sim_junior.py`
- `sim_junior/sulfonylation/parallel.py`
- `sim_junior/tips_pn/grignard.py`
- `sim_junior/tips_pn/quinone.py`
- `sim_junior/tips_pn/tandem.py`

Note:
- The bug related to drawio_diagram for drawing instructions is not fixed
- One bug exists in `sim_junior/sulfonylation/parallel.py` when dumping as json